### PR TITLE
[feat] 회원가입, 로그인, 유저정보 수정 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,11 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+	implementation 'org.springframework.boot:spring-boot-starter-security'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/dasom/MemoReal/UserManager/domain/controller/UserController.java
+++ b/src/main/java/com/dasom/MemoReal/UserManager/domain/controller/UserController.java
@@ -1,0 +1,65 @@
+package com.dasom.MemoReal.UserManager.domain.controller;
+
+import com.dasom.MemoReal.UserManager.domain.dto.*;
+import com.dasom.MemoReal.UserManager.domain.entity.User;
+import com.dasom.MemoReal.UserManager.domain.service.UserService;
+import com.dasom.MemoReal.UserManager.global.util.JwtUtil;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/users")
+public class UserController {
+    @Autowired
+    private UserService userService;
+
+    @PostMapping("/register")
+    public CommonResponse<?> register(@RequestBody UserRegisterRequest request) {
+        try {
+            User user = userService.register(request);
+            return new CommonResponse<>(false, user);
+        } catch (IllegalStateException e) {
+            return new CommonResponse<>(true, e.getMessage());
+        } catch (Exception e) {
+            return new CommonResponse<>(true, "회원가입 처리 중 오류가 발생했습니다: " + e.getMessage());
+        }
+    }
+
+    @PostMapping("/login")
+    public CommonResponse<?> login(@RequestBody LoginRequest request) {
+        try {
+            User user = userService.login(request.getEmail(), request.getPassword());
+
+            if (user == null) {
+                return new CommonResponse<>(true, "이메일 또는 비밀번호가 일치하지 않습니다.");
+            }
+
+            String token = JwtUtil.generateToken(user.getUsername());
+            LoginResponse response = new LoginResponse(token);
+
+            return new CommonResponse<>(false, response);
+
+        } catch (Exception e) {
+            return new CommonResponse<>(true, "로그인 처리 중 오류가 발생했습니다: " + e.getMessage());
+        }
+    }
+    @PutMapping("/update")
+    public CommonResponse<?> updateUserInfo(
+            @RequestHeader("Authorization") String authHeader,
+            @RequestBody Map<String, Object> updates) {
+        try {
+            String token = authHeader.startsWith("Bearer ") ? authHeader.substring(7) : authHeader;
+            String username = JwtUtil.extractUsername(token);
+
+            User updatedUser = userService.updateUserInfoByMap(username, updates);
+
+            return new CommonResponse<>(false, updatedUser);
+        } catch (IllegalStateException e) {
+            return new CommonResponse<>(true, e.getMessage());
+        } catch (Exception e) {
+            return new CommonResponse<>(true, "유저 정보 수정 중 오류가 발생했습니다: " + e.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/dasom/MemoReal/UserManager/domain/dto/CommonResponse.java
+++ b/src/main/java/com/dasom/MemoReal/UserManager/domain/dto/CommonResponse.java
@@ -1,0 +1,13 @@
+package com.dasom.MemoReal.UserManager.domain.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class CommonResponse<T> { // 데이터 반환값 형식
+    private boolean error;// 오류 발생여부
+    private T data; // 데이터 or 오류 코드
+}

--- a/src/main/java/com/dasom/MemoReal/UserManager/domain/dto/LoginRequest.java
+++ b/src/main/java/com/dasom/MemoReal/UserManager/domain/dto/LoginRequest.java
@@ -1,0 +1,13 @@
+package com.dasom.MemoReal.UserManager.domain.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class LoginRequest {
+    private String email;
+    private String password;
+}

--- a/src/main/java/com/dasom/MemoReal/UserManager/domain/dto/LoginResponse.java
+++ b/src/main/java/com/dasom/MemoReal/UserManager/domain/dto/LoginResponse.java
@@ -1,0 +1,13 @@
+package com.dasom.MemoReal.UserManager.domain.dto;
+
+import com.dasom.MemoReal.UserManager.domain.entity.User;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class LoginResponse {
+    private String jwt;
+}

--- a/src/main/java/com/dasom/MemoReal/UserManager/domain/dto/UserRegisterRequest.java
+++ b/src/main/java/com/dasom/MemoReal/UserManager/domain/dto/UserRegisterRequest.java
@@ -1,0 +1,13 @@
+package com.dasom.MemoReal.UserManager.domain.dto;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserRegisterRequest {
+    private String username;
+    private String email;
+    private String password;
+}

--- a/src/main/java/com/dasom/MemoReal/UserManager/domain/entity/User.java
+++ b/src/main/java/com/dasom/MemoReal/UserManager/domain/entity/User.java
@@ -1,0 +1,38 @@
+package com.dasom.MemoReal.UserManager.domain.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+import java.time.LocalDate;
+
+@Entity
+@Table(name = "users")
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class User {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long uid;
+
+    @Column(unique = true)
+    private String username;
+
+    private String email;
+    private String password;
+
+    @CreationTimestamp
+    @Column(updatable = false)
+    @JsonFormat(pattern = "yyyy-MM-dd", timezone = "Asia/Seoul") // JSON 응답 형식 지정
+    private LocalDate createdAt;
+
+    public User(String username, String email, String password) {
+        this.username = username;
+        this.email = email;
+        this.password = password;
+    }
+}

--- a/src/main/java/com/dasom/MemoReal/UserManager/domain/repository/UserRepository.java
+++ b/src/main/java/com/dasom/MemoReal/UserManager/domain/repository/UserRepository.java
@@ -1,0 +1,14 @@
+package com.dasom.MemoReal.UserManager.domain.repository;
+
+import com.dasom.MemoReal.UserManager.domain.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findByEmail(String email);
+    Optional<User> findByUsername(String username);
+    boolean existsByEmail(String email);
+    boolean existsByUsername(String username);
+    boolean existsByEmailAndPassword(String email, String password);
+}

--- a/src/main/java/com/dasom/MemoReal/UserManager/domain/service/UserService.java
+++ b/src/main/java/com/dasom/MemoReal/UserManager/domain/service/UserService.java
@@ -1,0 +1,78 @@
+package com.dasom.MemoReal.UserManager.domain.service;
+
+import com.dasom.MemoReal.UserManager.domain.dto.UserRegisterRequest;
+import com.dasom.MemoReal.UserManager.domain.entity.User;
+import com.dasom.MemoReal.UserManager.domain.repository.UserRepository;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Map;
+
+@Service
+public class UserService {
+
+    private final UserRepository repository;
+    private final PasswordEncoder passwordEncoder;
+
+    public UserService(UserRepository repository, PasswordEncoder passwordEncoder) {
+        this.repository = repository;
+        this.passwordEncoder = passwordEncoder; // 암호화기 초기화
+    }
+
+    @Transactional
+    public User register(UserRegisterRequest request) {
+        if (repository.existsByUsername(request.getUsername())) {
+            throw new IllegalStateException("이미 존재하는 사용자명입니다.");
+        }
+
+        if (repository.existsByEmail(request.getEmail())) {
+            throw new IllegalStateException("이미 존재하는 이메일입니다.");
+        }
+
+        // 비밀번호 암호화
+        String encodedPassword = passwordEncoder.encode(request.getPassword());
+
+        User user = new User(
+                request.getUsername(),
+                request.getEmail(),
+                encodedPassword
+        );
+
+        return repository.save(user);
+    }
+
+    @Transactional(readOnly = true)
+    public User login(String email, String rawPassword) {
+        return repository.findByEmail(email)
+                .filter(user -> passwordEncoder.matches(rawPassword, user.getPassword()))
+                .orElse(null);
+    }
+
+    @Transactional
+    public User updateUserInfoByMap(String username, Map<String, Object> updates) {
+        User user = repository.findByUsername(username)
+                .orElseThrow(() -> new IllegalStateException("사용자를 찾을 수 없습니다."));
+
+        for (Map.Entry<String, Object> entry : updates.entrySet()) {
+            String key = entry.getKey();
+            Object value = entry.getValue();
+
+            switch (key) {
+                case "username":
+                    user.setUsername((String) value);
+                    break;
+                case "email":
+                    throw new IllegalArgumentException("이메일은 수정할 수 없습니다.");
+                case "password":
+                    String encodedNewPassword = passwordEncoder.encode((String) value);
+                    user.setPassword(encodedNewPassword);
+                    break;
+                default:
+                    throw new IllegalArgumentException("수정할 수 없는 필드: " + key);
+            }
+        }
+
+        return repository.save(user);
+    }
+}

--- a/src/main/java/com/dasom/MemoReal/UserManager/domain/service/UserService.java
+++ b/src/main/java/com/dasom/MemoReal/UserManager/domain/service/UserService.java
@@ -50,8 +50,8 @@ public class UserService {
     }
 
     @Transactional
-    public User updateUserInfoByMap(String username, Map<String, Object> updates) {
-        User user = repository.findByUsername(username)
+    public User updateUserInfoByMap(String email, Map<String, Object> updates) {
+        User user = repository.findByEmail(email)
                 .orElseThrow(() -> new IllegalStateException("사용자를 찾을 수 없습니다."));
 
         for (Map.Entry<String, Object> entry : updates.entrySet()) {

--- a/src/main/java/com/dasom/MemoReal/UserManager/global/config/SecurityConfig.java
+++ b/src/main/java/com/dasom/MemoReal/UserManager/global/config/SecurityConfig.java
@@ -1,0 +1,15 @@
+package com.dasom.MemoReal.UserManager.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+public class SecurityConfig {
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/src/main/java/com/dasom/MemoReal/UserManager/global/util/JwtUtil.java
+++ b/src/main/java/com/dasom/MemoReal/UserManager/global/util/JwtUtil.java
@@ -1,0 +1,30 @@
+package com.dasom.MemoReal.UserManager.global.util;
+
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+
+import java.security.Key;
+import java.util.Date;
+
+public class JwtUtil {
+    private static final Key key = Keys.secretKeyFor(SignatureAlgorithm.HS256);
+    private static final long EXPIRATION_TIME = 86400000L; // 1일
+
+    public static String generateToken(String username) {
+        return Jwts.builder()
+                .setSubject(username)
+                .setExpiration(new Date(System.currentTimeMillis() + EXPIRATION_TIME))
+                .signWith(key)
+                .compact();
+    }
+
+    public static String extractUsername(String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(token)
+                .getBody()
+                .getSubject();
+    }
+}

--- a/src/test/java/com/dasom/MemoReal/UserTest/UserServiceIntegrationTest.java
+++ b/src/test/java/com/dasom/MemoReal/UserTest/UserServiceIntegrationTest.java
@@ -1,0 +1,117 @@
+package com.dasom.MemoReal.UserTest;
+
+import com.dasom.MemoReal.UserManager.domain.dto.UserRegisterRequest;
+import com.dasom.MemoReal.UserManager.domain.entity.User;
+import com.dasom.MemoReal.UserManager.domain.repository.UserRepository;
+import com.dasom.MemoReal.UserManager.domain.service.UserService;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+public class UserServiceIntegrationTest {
+
+    @Autowired
+    private UserService userService;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    private static final String TEST_USERNAME = "testuser";
+    private static final String TEST_EMAIL = "test@example.com";
+    private static final String TEST_PASSWORD = "testpass";
+
+    @Test
+    @Order(1)
+    @DisplayName("✅ 실제 DB에 유저 등록 테스트")
+    void registerUserToRealDB() {
+        System.out.println("---- [1] 유저 등록 테스트 시작 ----");
+
+        // given
+        UserRegisterRequest request = new UserRegisterRequest(
+                TEST_USERNAME, TEST_EMAIL, TEST_PASSWORD
+        );
+
+        // when
+        User savedUser = userService.register(request);
+
+        // then
+        User foundUser = userRepository.findByUsername(TEST_USERNAME).orElseThrow();
+
+        System.out.println("서비스 반환 User 객체:");
+        System.out.println(" - ID: " + savedUser.getUid());
+        System.out.println(" - Username: " + savedUser.getUsername());
+        System.out.println(" - Email: " + savedUser.getEmail());
+        System.out.println(" - Password (암호화됨): " + savedUser.getPassword());
+        System.out.println(" - CreatedAt: " + savedUser.getCreatedAt());
+
+        System.out.println("DB에서 조회한 User 객체:");
+        System.out.println(" - ID: " + foundUser.getUid());
+        System.out.println(" - Username: " + foundUser.getUsername());
+        System.out.println(" - Email: " + foundUser.getEmail());
+        System.out.println(" - Password (암호화됨): " + foundUser.getPassword());
+        System.out.println(" - CreatedAt: " + foundUser.getCreatedAt());
+
+
+        System.out.println("---- [1] 유저 등록 테스트 종료 ----\n");
+    }
+
+    @Test
+    @Order(2)
+    @DisplayName("✅ 로그인 기능 테스트")
+    void loginUserTest() {
+        System.out.println("---- [2] 로그인 테스트 시작 ----");
+
+        // given
+        String email = TEST_EMAIL;
+        String password = TEST_PASSWORD;
+
+        // when
+        User loggedInUser = userService.login(email, password);
+
+        System.out.println("로그인 후 반환된 User 객체:");
+        if (loggedInUser != null) {
+            System.out.println(" - ID: " + loggedInUser.getUid());
+            System.out.println(" - Username: " + loggedInUser.getUsername());
+            System.out.println(" - Email: " + loggedInUser.getEmail());
+            System.out.println(" - Password (암호화됨): " + loggedInUser.getPassword());
+            System.out.println(" - CreatedAt: " + loggedInUser.getCreatedAt());
+        } else {
+            System.out.println(" - 로그인 실패: User 객체가 null");
+        }
+
+        // then
+        assertThat(loggedInUser).isNotNull();
+        assertThat(loggedInUser.getEmail()).isEqualTo(email);
+        // 평문 비밀번호와 암호화된 비밀번호가 매칭되는지 확인
+        assertThat(passwordEncoder.matches(password, loggedInUser.getPassword())).isTrue();
+
+        System.out.println("---- [2] 로그인 테스트 종료 ----\n");
+    }
+
+    @Test
+    @Order(3)
+    @DisplayName("🧹 테스트 유저 삭제")
+    void cleanupTestUser() {
+        System.out.println("---- [3] 테스트 유저 삭제 시작 ----");
+
+        userRepository.findByUsername(TEST_USERNAME).ifPresent(user -> {
+            userRepository.delete(user);
+            System.out.println("🗑️ 삭제 완료 - username: " + user.getUsername());
+        });
+
+        boolean exists = userRepository.existsByUsername(TEST_USERNAME);
+        System.out.println("삭제 후 사용자 존재 여부: " + exists);
+
+        assertThat(exists).isFalse();
+
+        System.out.println("---- [3] 테스트 유저 삭제 종료 ----\n");
+    }
+}

--- a/src/test/java/com/dasom/MemoReal/UserTest/UserServiceIntegrationTest.java
+++ b/src/test/java/com/dasom/MemoReal/UserTest/UserServiceIntegrationTest.java
@@ -9,6 +9,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
+import java.util.Map;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest
@@ -59,7 +61,6 @@ public class UserServiceIntegrationTest {
         System.out.println(" - Password (암호화됨): " + foundUser.getPassword());
         System.out.println(" - CreatedAt: " + foundUser.getCreatedAt());
 
-
         System.out.println("---- [1] 유저 등록 테스트 종료 ----\n");
     }
 
@@ -98,20 +99,61 @@ public class UserServiceIntegrationTest {
 
     @Test
     @Order(3)
+    @DisplayName("✅ 회원정보 수정 테스트 (DB 값과 요청값, 결과 출력)")
+    void updateUserInfoTest() {
+        System.out.println("---- [3] 회원정보 수정 테스트 시작 ----");
+
+        // 1. 수정 전 DB의 기존 값 조회 및 출력
+        User userBeforeUpdate = userRepository.findByEmail(TEST_EMAIL).orElseThrow();
+        System.out.println("수정 전 DB User 객체:");
+        System.out.println(" - ID: " + userBeforeUpdate.getUid());
+        System.out.println(" - Username: " + userBeforeUpdate.getUsername());
+        System.out.println(" - Email: " + userBeforeUpdate.getEmail());
+        System.out.println(" - Password (암호화됨): " + userBeforeUpdate.getPassword());
+        System.out.println(" - CreatedAt: " + userBeforeUpdate.getCreatedAt());
+
+        // 2. 수정 요청 값 생성 및 출력
+        Map<String, Object> updates = Map.of(
+                "username", "updatedUser",
+                "password", "newpassword"
+        );
+        System.out.println("수정 요청값:");
+        updates.forEach((k, v) -> System.out.println(" - " + k + ": " + v));
+
+        // 3. 수정 수행
+        User updatedUser = userService.updateUserInfoByMap(userBeforeUpdate.getEmail(), updates);
+
+        // 4. 수정 후 결과 출력
+        System.out.println("수정 후 User 객체:");
+        System.out.println(" - ID: " + updatedUser.getUid());
+        System.out.println(" - Username: " + updatedUser.getUsername());
+        System.out.println(" - Email: " + updatedUser.getEmail());
+        System.out.println(" - Password (암호화됨): " + updatedUser.getPassword());
+        System.out.println(" - CreatedAt: " + updatedUser.getCreatedAt());
+
+        // 5. 검증
+        assertThat(updatedUser.getUsername()).isEqualTo("updatedUser");
+        assertThat(passwordEncoder.matches("newpassword", updatedUser.getPassword())).isTrue();
+
+        System.out.println("---- [3] 회원정보 수정 테스트 종료 ----\n");
+    }
+
+    @Test
+    @Order(4)
     @DisplayName("🧹 테스트 유저 삭제")
     void cleanupTestUser() {
-        System.out.println("---- [3] 테스트 유저 삭제 시작 ----");
+        System.out.println("---- [4] 테스트 유저 삭제 시작 ----");
 
-        userRepository.findByUsername(TEST_USERNAME).ifPresent(user -> {
+        userRepository.findByEmail(TEST_EMAIL).ifPresent(user -> {
             userRepository.delete(user);
-            System.out.println("🗑️ 삭제 완료 - username: " + user.getUsername());
+            System.out.println("🗑️ 삭제 완료 - email: " + user.getEmail());
         });
 
-        boolean exists = userRepository.existsByUsername(TEST_USERNAME);
+        boolean exists = userRepository.existsByEmail(TEST_EMAIL);
         System.out.println("삭제 후 사용자 존재 여부: " + exists);
 
         assertThat(exists).isFalse();
 
-        System.out.println("---- [3] 테스트 유저 삭제 종료 ----\n");
+        System.out.println("---- [4] 테스트 유저 삭제 종료 ----\n");
     }
 }

--- a/src/test/java/com/dasom/MemoReal/UserTest/UserServiceTest.java
+++ b/src/test/java/com/dasom/MemoReal/UserTest/UserServiceTest.java
@@ -139,12 +139,12 @@ class UserServiceTest {
             System.out.println("──────────── username 수정 테스트 시작 ────────────");
 
             User user = new User("user1", "user@example.com", "pass");
-            when(repository.findByUsername("user1")).thenReturn(Optional.of(user));
+            when(repository.findByEmail("user@example.com")).thenReturn(Optional.of(user));
             when(repository.save(any(User.class))).thenAnswer(i -> i.getArguments()[0]);
 
             Map<String, Object> updates = Map.of("username", "newUser");
 
-            User result = userService.updateUserInfoByMap("user1", updates);
+            User result = userService.updateUserInfoByMap("user@example.com", updates);
 
             System.out.println("✅ username 수정 성공 - username: " + result.getUsername());
 
@@ -157,11 +157,11 @@ class UserServiceTest {
             System.out.println("──────────── email 수정 시도 테스트 시작 ────────────");
 
             User user = new User("user1", "user@example.com", "pass");
-            when(repository.findByUsername("user1")).thenReturn(Optional.of(user));
+            when(repository.findByEmail("user@example.com")).thenReturn(Optional.of(user));
 
             Map<String, Object> updates = Map.of("email", "new@example.com");
 
-            assertThatThrownBy(() -> userService.updateUserInfoByMap("user1", updates))
+            assertThatThrownBy(() -> userService.updateUserInfoByMap("user@example.com", updates))
                     .isInstanceOf(IllegalArgumentException.class)
                     .hasMessage("이메일은 수정할 수 없습니다.")
                     .satisfies(e -> {
@@ -176,13 +176,13 @@ class UserServiceTest {
             System.out.println("──────────── password 수정 테스트 시작 ────────────");
 
             User user = new User("user1", "user@example.com", "oldpass");
-            when(repository.findByUsername("user1")).thenReturn(Optional.of(user));
+            when(repository.findByEmail("user@example.com")).thenReturn(Optional.of(user));
             when(passwordEncoder.encode("newpass")).thenReturn("encoded_newpass");
             when(repository.save(any(User.class))).thenAnswer(i -> i.getArguments()[0]);
 
             Map<String, Object> updates = Map.of("password", "newpass");
 
-            User result = userService.updateUserInfoByMap("user1", updates);
+            User result = userService.updateUserInfoByMap("user@example.com", updates);
 
             System.out.println("✅ password 수정 성공 - password: " + result.getPassword());
 
@@ -195,11 +195,11 @@ class UserServiceTest {
             System.out.println("──────────── 허용되지 않은 필드 수정 테스트 시작 ────────────");
 
             User user = new User("user1", "user@example.com", "pass");
-            when(repository.findByUsername("user1")).thenReturn(Optional.of(user));
+            when(repository.findByEmail("user@example.com")).thenReturn(Optional.of(user));
 
             Map<String, Object> updates = Map.of("role", "admin");
 
-            assertThatThrownBy(() -> userService.updateUserInfoByMap("user1", updates))
+            assertThatThrownBy(() -> userService.updateUserInfoByMap("user@example.com", updates))
                     .isInstanceOf(IllegalArgumentException.class)
                     .hasMessage("수정할 수 없는 필드: role")
                     .satisfies(e -> {
@@ -213,11 +213,11 @@ class UserServiceTest {
         void update_userNotFound() {
             System.out.println("──────────── 사용자 없음 테스트 시작 ────────────");
 
-            when(repository.findByUsername("unknown")).thenReturn(Optional.empty());
+            when(repository.findByEmail("unknown@example.com")).thenReturn(Optional.empty());
 
             Map<String, Object> updates = Map.of("intro", "intro");
 
-            assertThatThrownBy(() -> userService.updateUserInfoByMap("unknown", updates))
+            assertThatThrownBy(() -> userService.updateUserInfoByMap("unknown@example.com", updates))
                     .isInstanceOf(IllegalStateException.class)
                     .hasMessage("사용자를 찾을 수 없습니다.")
                     .satisfies(e -> {
@@ -226,4 +226,5 @@ class UserServiceTest {
                     });
         }
     }
+
 }

--- a/src/test/java/com/dasom/MemoReal/UserTest/UserServiceTest.java
+++ b/src/test/java/com/dasom/MemoReal/UserTest/UserServiceTest.java
@@ -1,0 +1,229 @@
+package com.dasom.MemoReal.UserTest;
+
+import com.dasom.MemoReal.UserManager.domain.dto.UserRegisterRequest;
+import com.dasom.MemoReal.UserManager.domain.entity.User;
+import com.dasom.MemoReal.UserManager.domain.repository.UserRepository;
+import com.dasom.MemoReal.UserManager.domain.service.UserService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.util.Map;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class UserServiceTest {
+
+    private UserRepository repository;
+    private PasswordEncoder passwordEncoder;
+    private UserService userService;
+
+    @BeforeEach
+    void setUp() {
+        repository = mock(UserRepository.class);
+        passwordEncoder = mock(PasswordEncoder.class);
+        userService = new UserService(repository,passwordEncoder);
+    }
+
+    @Nested
+    @DisplayName("회원가입 테스트")
+    class RegisterTest {
+
+        @Test
+        @DisplayName("성공")
+        void register_success() {
+            System.out.println("──────────── 회원가입 성공 테스트 시작 ────────────");
+
+            UserRegisterRequest request = new UserRegisterRequest("user1", "user@example.com", "pass");
+
+            when(repository.existsByUsername("user1")).thenReturn(false);
+            when(repository.existsByEmail("user@example.com")).thenReturn(false);
+            when(passwordEncoder.encode("pass")).thenReturn("encoded_pass");
+            when(repository.save(any(User.class))).thenAnswer(i -> i.getArguments()[0]);
+
+            User user = userService.register(request);
+
+            System.out.println("✅ 회원가입 성공 - username: " + user.getUsername());
+
+            assertThat(user.getUsername()).isEqualTo("user1");
+            assertThat(user.getPassword()).isEqualTo("encoded_pass");
+        }
+
+        @Test
+        @DisplayName("이미 존재하는 사용자명")
+        void register_duplicateUsername() {
+            System.out.println("──────────── 사용자명 중복 테스트 시작 ────────────");
+
+            UserRegisterRequest request = new UserRegisterRequest("user1", "user@example.com", "pass");
+            when(repository.existsByUsername("user1")).thenReturn(true);
+
+            assertThatThrownBy(() -> userService.register(request))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessage("이미 존재하는 사용자명입니다.")
+                    .satisfies(e -> {
+                        System.out.println("▶ 예외 메시지: " + e.getMessage());
+                        System.out.println("✅ 예외가 정상적으로 처리되었습니다.");
+                    });
+        }
+
+        @Test
+        @DisplayName("이미 존재하는 이메일")
+        void register_duplicateEmail() {
+            System.out.println("──────────── 이메일 중복 테스트 시작 ────────────");
+
+            UserRegisterRequest request = new UserRegisterRequest("user1", "user@example.com", "pass");
+
+            when(repository.existsByUsername("user1")).thenReturn(false);
+            when(repository.existsByEmail("user@example.com")).thenReturn(true);
+
+            assertThatThrownBy(() -> userService.register(request))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessage("이미 존재하는 이메일입니다.")
+                    .satisfies(e -> {
+                        System.out.println("▶ 예외 메시지: " + e.getMessage());
+                        System.out.println("✅ 예외가 정상적으로 처리되었습니다.");
+                    });
+        }
+    }
+
+    @Nested
+    @DisplayName("로그인 테스트")
+    class LoginTest {
+
+        @Test
+        @DisplayName("성공")
+        void login_success() {
+            System.out.println("──────────── 로그인 성공 테스트 시작 ────────────");
+
+            User user = new User("user1", "user@example.com", "encoded_pass");
+
+            when(repository.findByEmail("user@example.com")).thenReturn(Optional.of(user));
+            when(passwordEncoder.matches("pass", "encoded_pass")).thenReturn(true);
+
+            User result = userService.login("user@example.com", "pass");
+
+            System.out.println("✅ 로그인 성공 - username: " + result.getUsername());
+
+            assertThat(result).isNotNull();
+            assertThat(result.getUsername()).isEqualTo("user1");
+        }
+
+        @Test
+        @DisplayName("이메일/비밀번호 불일치")
+        void login_invalid() {
+            System.out.println("──────────── 로그인 실패 테스트 시작 ────────────");
+
+            User user = new User("user1", "user@example.com", "encoded_pass");
+            when(repository.findByEmail("user@example.com")).thenReturn(Optional.of(user));
+            when(passwordEncoder.matches("wrongpass", "encoded_pass")).thenReturn(false);
+
+            User result = userService.login("user@example.com", "wrongpass");
+
+            System.out.println("❌ 로그인 실패 - 유저 없음 (결과가 null)");
+
+            assertThat(result).isNull();
+        }
+    }
+
+    @Nested
+    @DisplayName("유저 정보 수정 테스트")
+    class UpdateUserInfoTest {
+
+        @Test
+        @DisplayName("username 수정 성공")
+        void update_usernameChange() {
+            System.out.println("──────────── username 수정 테스트 시작 ────────────");
+
+            User user = new User("user1", "user@example.com", "pass");
+            when(repository.findByUsername("user1")).thenReturn(Optional.of(user));
+            when(repository.save(any(User.class))).thenAnswer(i -> i.getArguments()[0]);
+
+            Map<String, Object> updates = Map.of("username", "newUser");
+
+            User result = userService.updateUserInfoByMap("user1", updates);
+
+            System.out.println("✅ username 수정 성공 - username: " + result.getUsername());
+
+            assertThat(result.getUsername()).isEqualTo("newUser");
+        }
+
+        @Test
+        @DisplayName("email 수정 시도")
+        void update_emailChange() {
+            System.out.println("──────────── email 수정 시도 테스트 시작 ────────────");
+
+            User user = new User("user1", "user@example.com", "pass");
+            when(repository.findByUsername("user1")).thenReturn(Optional.of(user));
+
+            Map<String, Object> updates = Map.of("email", "new@example.com");
+
+            assertThatThrownBy(() -> userService.updateUserInfoByMap("user1", updates))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessage("이메일은 수정할 수 없습니다.")
+                    .satisfies(e -> {
+                        System.out.println("▶ 예외 메시지: " + e.getMessage());
+                        System.out.println("✅ 예외가 정상적으로 처리되었습니다.");
+                    });
+        }
+
+        @Test
+        @DisplayName("password 수정 성공")
+        void update_passwordChange() {
+            System.out.println("──────────── password 수정 테스트 시작 ────────────");
+
+            User user = new User("user1", "user@example.com", "oldpass");
+            when(repository.findByUsername("user1")).thenReturn(Optional.of(user));
+            when(passwordEncoder.encode("newpass")).thenReturn("encoded_newpass");
+            when(repository.save(any(User.class))).thenAnswer(i -> i.getArguments()[0]);
+
+            Map<String, Object> updates = Map.of("password", "newpass");
+
+            User result = userService.updateUserInfoByMap("user1", updates);
+
+            System.out.println("✅ password 수정 성공 - password: " + result.getPassword());
+
+            assertThat(result.getPassword()).isEqualTo("encoded_newpass");
+        }
+
+        @Test
+        @DisplayName("허용되지 않은 필드 수정 시도")
+        void update_invalidField() {
+            System.out.println("──────────── 허용되지 않은 필드 수정 테스트 시작 ────────────");
+
+            User user = new User("user1", "user@example.com", "pass");
+            when(repository.findByUsername("user1")).thenReturn(Optional.of(user));
+
+            Map<String, Object> updates = Map.of("role", "admin");
+
+            assertThatThrownBy(() -> userService.updateUserInfoByMap("user1", updates))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessage("수정할 수 없는 필드: role")
+                    .satisfies(e -> {
+                        System.out.println("▶ 예외 메시지: " + e.getMessage());
+                        System.out.println("✅ 예외가 정상적으로 처리되었습니다.");
+                    });
+        }
+
+        @Test
+        @DisplayName("사용자 없음")
+        void update_userNotFound() {
+            System.out.println("──────────── 사용자 없음 테스트 시작 ────────────");
+
+            when(repository.findByUsername("unknown")).thenReturn(Optional.empty());
+
+            Map<String, Object> updates = Map.of("intro", "intro");
+
+            assertThatThrownBy(() -> userService.updateUserInfoByMap("unknown", updates))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessage("사용자를 찾을 수 없습니다.")
+                    .satisfies(e -> {
+                        System.out.println("▶ 예외 메시지: " + e.getMessage());
+                        System.out.println("✅ 예외가 정상적으로 처리되었습니다.");
+                    });
+        }
+    }
+}


### PR DESCRIPTION
# [feat] 회원가입, 로그인, 유저정보 수정 기능 구현
ex) [feat] 로그인 기능 추가

## 😺 Issue
- #9

## ✅ 작업 리스트
- 회원가입 기능 구현
- 로그인 기능 구현
- 회원정보 수정 구현
- 서비스 각 기능 및 예외처리에 대한 테스트 코드 작성
- 실제 DB에 회원가입, 로그인, 정보수정, 회원삭제 하는 테스트 코드 작성


## ⚙️ 작업 내용
- 회원 가입 시 이름, 이메일, 비밀번호 입력받으며, 자동으로 UID, createdAt(계정 생성 일자) 를 부여하며, 비밀번호는 해싱하여 저장
- 로그인 시 입력받은 이메일, 비밀번호 중 비밀번호는 해싱하며, 이메일이 있는지 1차로 찾고 2차로 비밀번호를 비교해서 처리
- 회원정보 수정 시 {계정이름, map(속성명, 변경 후 값)} 형식으로 요청받아서 처리하며 ,이메일, 계정생성일 같은 속성은 수정 불가능
- 유효성검사, 중복 체크, 사용자 없음 등의 기본적인 예외처리 완료 및 해당 오류 발생 시 프론트에 commonResponce로 (true,해당 오류에 대한 설명) 형식으로 커스텀 오류 문구 반환
## 📷 테스트 / 구현 내용
<img width="472" height="550" alt="image" src="https://github.com/user-attachments/assets/9e562073-d3e2-4c91-b072-d805651d3cad" />
<img width="696" height="517" alt="image" src="https://github.com/user-attachments/assets/ad1a5e7e-9306-4bcb-be9c-beb724a828ba" />
<img width="732" height="502" alt="image" src="https://github.com/user-attachments/assets/6e4dab38-0575-4b73-9bdf-69b6ec81eafa" />

