### PR TITLE
[feat] Jwt, Security  설정 및 사용자 정의 예외처리 구현

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -45,6 +45,7 @@ jobs:
             echo "DB_URL=${{ secrets.DB_URL }}" > /home/ubuntu/.env
             echo "DB_USERNAME=${{ secrets.DB_USERNAME }}" >> /home/ubuntu/.env
             echo "DB_PASSWORD=${{ secrets.DB_PASSWORD }}" >> /home/ubuntu/.env
+            echo "JWT_SECRET=${{ secrets.JWT_SECRET }}" >> /home/ubuntu/.env
             
             docker login -u ${{ secrets.DOCKERHUB_USERNAME }} -p ${{ secrets.DOCKERHUB_TOKEN }}
             docker pull kjunh972/dasom_memoreal:latest

--- a/.github/workflows/inspect-test.yml
+++ b/.github/workflows/inspect-test.yml
@@ -27,4 +27,5 @@ jobs:
           DB_URL: ${{ secrets.DB_URL }}
           DB_USERNAME: ${{ secrets.DB_USERNAME }}
           DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
+          JWT_SECRET: ${{ secrets.JWT_SECRET }}
         run: ./gradlew -Dspring.profiles.active=dev test

--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ out/
 
 ### env ###
 .env
+
+### macOS ###
+.DS_Store

--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,16 @@ repositories {
 }
 
 dependencies {
+	// Security
+	implementation 'org.springframework.boot:spring-boot-starter-security'
+	testImplementation 'org.springframework.security:spring-security-test'
+
+	//JWT
+	implementation 'io.jsonwebtoken:jjwt-api:0.12.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.5'
+
+
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-web'

--- a/src/main/java/com/dasom/MemoReal/domain/user/controller/UserController.java
+++ b/src/main/java/com/dasom/MemoReal/domain/user/controller/UserController.java
@@ -1,0 +1,40 @@
+package com.dasom.MemoReal.domain.user.controller;
+
+import com.dasom.MemoReal.domain.user.dto.JoinDTO;
+import com.dasom.MemoReal.domain.user.dto.LoginDTO;
+import com.dasom.MemoReal.domain.user.dto.UserDTO;
+import com.dasom.MemoReal.domain.user.service.UserService;
+import com.dasom.MemoReal.global.jwt.dto.JwtTokenDTO;
+import com.dasom.MemoReal.global.security.util.SecurityUtil;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class UserController {
+    private final UserService userService;
+
+    @PostMapping("/login")
+    public JwtTokenDTO login(@RequestBody LoginDTO loginDto) {
+        String email = loginDto.getEmail();
+        String password = loginDto.getPassword();
+        JwtTokenDTO jwtToken = userService.login(email, password);
+        return jwtToken;
+    }
+
+    @PostMapping("/join")
+    public ResponseEntity<UserDTO> join(@RequestBody JoinDTO joinDto) {
+        UserDTO savedUserDto = userService.join(joinDto);
+        return ResponseEntity.ok(savedUserDto);
+    }
+
+
+    // 임시 테스트 토큰이 있는 사용자가 요청 시, 사용자의 닉네임 반환
+    @PostMapping("/test")
+    public String test() {
+        return SecurityUtil.getCurrentUsername();
+    }
+}

--- a/src/main/java/com/dasom/MemoReal/domain/user/dto/JoinDTO.java
+++ b/src/main/java/com/dasom/MemoReal/domain/user/dto/JoinDTO.java
@@ -1,0 +1,31 @@
+package com.dasom.MemoReal.domain.user.dto;
+
+
+import com.dasom.MemoReal.domain.user.entity.User;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class JoinDTO {
+    private String email;
+    private String password;
+    private String username;
+    private List<String> roles = new ArrayList<>();
+
+    public User toEntity(String encodedPassword, List<String> roles) {
+        return User.builder()
+                .username(username)
+                .password(encodedPassword)
+                .email(email)
+                .roles(roles)
+                .build();
+    }
+}

--- a/src/main/java/com/dasom/MemoReal/domain/user/dto/LoginDTO.java
+++ b/src/main/java/com/dasom/MemoReal/domain/user/dto/LoginDTO.java
@@ -1,0 +1,15 @@
+package com.dasom.MemoReal.domain.user.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@ToString
+@NoArgsConstructor
+public class LoginDTO {
+    private String email;
+    private String password;
+}

--- a/src/main/java/com/dasom/MemoReal/domain/user/dto/UserDTO.java
+++ b/src/main/java/com/dasom/MemoReal/domain/user/dto/UserDTO.java
@@ -1,0 +1,33 @@
+package com.dasom.MemoReal.domain.user.dto;
+
+
+import com.dasom.MemoReal.domain.user.entity.User;
+import lombok.*;
+
+@Getter
+@ToString
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class UserDTO {
+    private Long id;
+    private String email;
+    private String username;
+
+    static public UserDTO toDto(User user) {
+        return UserDTO.builder()
+                .id(user.getId())
+                .username(user.getUsername())
+                .email(user.getEmail())
+                .build();
+    }
+
+    public User toEntity() {
+        return User.builder()
+                .id(id)
+                .username(username)
+                .email(email)
+                .build();
+    }
+
+}

--- a/src/main/java/com/dasom/MemoReal/domain/user/entity/User.java
+++ b/src/main/java/com/dasom/MemoReal/domain/user/entity/User.java
@@ -1,0 +1,60 @@
+package com.dasom.MemoReal.domain.user.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class User implements UserDetails {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private String username;
+    private String password;
+    private String email;
+
+    @ElementCollection(fetch = FetchType.EAGER)
+    @Builder.Default // 기본값 지정
+    private List<String> roles = new ArrayList<>();
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return this.roles.stream()
+                .map(SimpleGrantedAuthority::new)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+}

--- a/src/main/java/com/dasom/MemoReal/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/dasom/MemoReal/domain/user/repository/UserRepository.java
@@ -1,0 +1,13 @@
+package com.dasom.MemoReal.domain.user.repository;
+
+import com.dasom.MemoReal.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findByUsername(String username);
+    Optional<User> findByEmail(String email);
+
+    boolean existsByUsername(String username);
+}

--- a/src/main/java/com/dasom/MemoReal/domain/user/service/UserService.java
+++ b/src/main/java/com/dasom/MemoReal/domain/user/service/UserService.java
@@ -1,0 +1,60 @@
+package com.dasom.MemoReal.domain.user.service;
+
+import com.dasom.MemoReal.domain.user.dto.JoinDTO;
+import com.dasom.MemoReal.domain.user.dto.UserDTO;
+import com.dasom.MemoReal.domain.user.entity.User;
+import com.dasom.MemoReal.domain.user.repository.UserRepository;
+import com.dasom.MemoReal.global.jwt.dto.JwtTokenDTO;
+import com.dasom.MemoReal.global.jwt.provider.JwtTokenProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.bind.annotation.PostMapping;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@RequiredArgsConstructor
+@Service
+@Transactional(readOnly=true)
+public class UserService {
+    private final UserRepository userRepository;
+    private final AuthenticationManagerBuilder authenticationManagerBuilder;
+    private final JwtTokenProvider jwtTokenProvider;
+    private final PasswordEncoder passwordEncoder;
+
+    @Transactional
+    public JwtTokenDTO login(String email, String password) {
+        // 1. username + password 를 기반으로 Authentication 객체 생성
+        // 이때 authentication 은 인증 여부를 확인하는 authenticated 값이 false
+        UsernamePasswordAuthenticationToken authenticationToken = new UsernamePasswordAuthenticationToken(email, password);
+
+        // 2. 실제 검증. authenticate() 메서드를 통해 요청된 Member 에 대한 검증 진행
+        // authenticate 메서드가 실행될 때 CustomUserDetailsService 에서 만든 loadUserByUsername 메서드 실행
+        Authentication authentication = authenticationManagerBuilder.getObject().authenticate(authenticationToken);
+
+        // 3. 인증 정보를 기반으로 JWT 토큰 생성 + return
+        return jwtTokenProvider.generateToken(authentication);
+    }
+
+    @Transactional
+    public UserDTO join(JoinDTO signUpDto) {
+        if (userRepository.existsByUsername(signUpDto.getUsername())) {
+            throw new IllegalArgumentException("이미 사용 중인 사용자 이름입니다.");
+        }
+        // Password 암호화
+        String encodedPassword = passwordEncoder.encode(signUpDto.getPassword());
+        List<String> roles = new ArrayList<>();
+        roles.add("USER");  // USER 권한 부여
+        return UserDTO.toDto(userRepository.save(signUpDto.toEntity(encodedPassword, roles)));
+    }
+
+    @PostMapping("/test")
+    public String test() {
+        return "success";
+    }
+}

--- a/src/main/java/com/dasom/MemoReal/global/exception/CustomException.java
+++ b/src/main/java/com/dasom/MemoReal/global/exception/CustomException.java
@@ -1,0 +1,19 @@
+package com.dasom.MemoReal.global.exception;
+
+
+import lombok.Getter;
+
+@Getter
+public class CustomException extends RuntimeException {
+    private final ErrorCode errorCode;
+
+    public CustomException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+
+    public CustomException(ErrorCode errorCode, String customMessage) {
+        super(customMessage);
+        this.errorCode = errorCode;
+    }// 에러코드는 공유하되 메시지 커스텀 해서 사용
+}

--- a/src/main/java/com/dasom/MemoReal/global/exception/ErrorCode.java
+++ b/src/main/java/com/dasom/MemoReal/global/exception/ErrorCode.java
@@ -1,0 +1,32 @@
+package com.dasom.MemoReal.global.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum ErrorCode {
+    // 유저 등록, 수정
+    DUPLICATE_USERNAME("USER_001", HttpStatus.CONFLICT, "이미 존재하는 사용자명입니다."),
+    DUPLICATE_EMAIL("USER_002", HttpStatus.CONFLICT, "이미 존재하는 이메일입니다."),
+    USER_UPDATE_NOT_FOUND("USER_003", HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),
+    INVALID_UPDATE_FIELD("USER_004", HttpStatus.BAD_REQUEST, "수정할 수 없는 필드입니다."),
+
+    // 사용자 로그인 관련 에러
+    USER_NOT_FOUND("AUTH_001", HttpStatus.NOT_FOUND, "이메일이 존재하지 않습니다."),
+    INVALID_PASSWORD("AUTH_002", HttpStatus.UNAUTHORIZED, "비밀번호가 일치하지 않습니다."),
+
+    // 일반적인 에러(유효성 검사 등)
+    INVALID_INPUT_VALUE("COMMON_001", HttpStatus.BAD_REQUEST, "유효하지 않은 입력 값입니다."),
+    UNAUTHORIZED("COMMON_002", HttpStatus.UNAUTHORIZED, "인증되지 않은 접근입니다."),
+    INTERNAL_SERVER_ERROR("COMMON_999", HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류가 발생했습니다.");
+
+    private final String code;
+    private final HttpStatus httpStatus;
+    private final String message;
+
+    ErrorCode(String code, HttpStatus httpStatus, String message) {
+        this.code = code;
+        this.httpStatus = httpStatus;
+        this.message = message;
+    }
+}

--- a/src/main/java/com/dasom/MemoReal/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/dasom/MemoReal/global/exception/GlobalExceptionHandler.java
@@ -1,0 +1,44 @@
+package com.dasom.MemoReal.global.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Map;
+
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    private static final Logger log = LoggerFactory.getLogger(GlobalExceptionHandler.class);
+
+    // 사용자 정의 예외 처리 (비즈니스, 서버 예외)
+    @ExceptionHandler(CustomException.class)
+    protected ResponseEntity<?> handleCustomException(CustomException e) {
+        ErrorCode code = e.getErrorCode();
+        HttpStatus status = code.getHttpStatus();
+        log.warn("CustomException occurred: {}", code.getMessage(), e);
+        return ResponseEntity
+                .status(status)
+                .body(Map.of(
+                        "success", false,
+                        "error", code.getMessage()
+                )); // 오류라 success=false와 에러 메시지 전달 // 오류라 success=false
+    }
+
+    // 예기치 못한 예외 처리
+    @ExceptionHandler(Exception.class)
+    protected ResponseEntity<?> handleException(Exception e) {
+        log.error("Unhandled Exception: {}", e.getMessage(), e);
+        return ResponseEntity
+                .status(ErrorCode.INTERNAL_SERVER_ERROR.getHttpStatus())
+                .body(Map.of(
+                        "success", false,
+                        "error", "Internal Server Error"
+                ));// 오류라 success=false
+    }
+
+}

--- a/src/main/java/com/dasom/MemoReal/global/jwt/dto/JwtTokenDTO.java
+++ b/src/main/java/com/dasom/MemoReal/global/jwt/dto/JwtTokenDTO.java
@@ -1,0 +1,14 @@
+package com.dasom.MemoReal.global.jwt.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+
+@Builder
+@Data
+@AllArgsConstructor
+public class JwtTokenDTO {
+    private String grantType;
+    private String accessToken;
+    private String refreshToken;
+}

--- a/src/main/java/com/dasom/MemoReal/global/jwt/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/dasom/MemoReal/global/jwt/filter/JwtAuthenticationFilter.java
@@ -1,0 +1,47 @@
+package com.dasom.MemoReal.global.jwt.filter;
+
+import com.dasom.MemoReal.global.jwt.provider.JwtTokenProvider;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.GenericFilterBean;
+
+import java.io.IOException;
+
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends GenericFilterBean {
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Override
+    public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse, FilterChain filterChain) throws IOException, ServletException {
+        // 1. Request Header에서 JWT 토큰 추출
+        String token = resolveToken((HttpServletRequest) servletRequest);
+
+        // 2. validateToken으로 토큰 유효성 검사
+        if (token != null && jwtTokenProvider.validateToken(token)) {
+            // 토큰이 유효할 경우 토큰에서 Authentication 객체를 가지고 와서 SecurityContext에 저장
+            Authentication authentication = jwtTokenProvider.getAuthentication(token);
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        }
+
+        filterChain.doFilter(servletRequest, servletResponse);
+    }
+
+    private String resolveToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader("Authorization");
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer")) {
+            return bearerToken.substring(7);
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/dasom/MemoReal/global/jwt/provider/JwtTokenProvider.java
+++ b/src/main/java/com/dasom/MemoReal/global/jwt/provider/JwtTokenProvider.java
@@ -1,0 +1,125 @@
+package com.dasom.MemoReal.global.jwt.provider;
+
+import com.dasom.MemoReal.global.jwt.dto.JwtTokenDTO;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.UnsupportedJwtException;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+
+import lombok.extern.slf4j.Slf4j;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Component;
+
+import java.security.Key;
+import java.util.*;
+import java.util.stream.Collectors;
+
+
+@Slf4j
+@Component
+public class JwtTokenProvider {
+    private final Key key;
+
+    // application.yml에서 secret 값 가져와서 key에 저장
+    public JwtTokenProvider(@Value("${JWT_SECRET}") String secretKey) {
+        byte[] keyBytes = Decoders.BASE64.decode(secretKey);
+        this.key = Keys.hmacShaKeyFor(keyBytes);
+    }
+
+    // Member 정보를 가지고 AccessToken, RefreshToken을 생성하는 메서드
+    public JwtTokenDTO generateToken(Authentication authentication) {
+        // 권한 가져오기
+        String authorities = authentication.getAuthorities().stream()
+                .map(GrantedAuthority::getAuthority)
+                .collect(Collectors.joining(","));
+
+        long now = (new Date()).getTime();
+
+        // Access Token 생성
+        Date accessTokenExpiresIn = new Date(now + 86400000);
+        String accessToken = Jwts.builder()
+                .setSubject(authentication.getName())
+                .claim("auth", authorities)
+                .setExpiration(accessTokenExpiresIn)
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+
+        // Refresh Token 생성
+        String refreshToken = Jwts.builder()
+                .setExpiration(new Date(now + 86400000))
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+
+        return JwtTokenDTO.builder()
+                .grantType("Bearer")
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .build();
+    }
+
+    // Jwt 토큰을 복호화하여 토큰에 들어있는 정보를 꺼내는 메서드
+    public Authentication getAuthentication(String accessToken) {
+        // Jwt 토큰 복호화
+        Claims claims = parseClaims(accessToken);
+
+        if (claims.get("auth") == null) {
+            throw new RuntimeException("권한 정보가 없는 토큰입니다.");
+        }
+
+        // 클레임에서 권한 정보 가져오기
+        Collection<? extends GrantedAuthority> authorities = Arrays.stream(claims.get("auth").toString().split(","))
+                .map(SimpleGrantedAuthority::new)
+                .collect(Collectors.toList());
+
+        // UserDetails 객체를 만들어서 Authentication return
+        // UserDetails: interface, User: UserDetails를 구현한 class
+        UserDetails principal = new User(claims.getSubject(), "", authorities);
+        return new UsernamePasswordAuthenticationToken(principal, "", authorities);
+    }
+
+    // 토큰 정보를 검증하는 메서드
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parser()
+                    .setSigningKey(key)
+                    .build()
+                    .parseClaimsJws(token);
+            return true;
+        } catch (SecurityException | MalformedJwtException e) {
+            log.info("Invalid JWT Token", e);
+        } catch (ExpiredJwtException e) {
+            log.info("Expired JWT Token", e);
+        } catch (UnsupportedJwtException e) {
+            log.info("Unsupported JWT Token", e);
+        } catch (IllegalArgumentException e) {
+            log.info("JWT claims string is empty.", e);
+        }
+        return false;
+    }
+
+
+    // accessToken
+    private Claims parseClaims(String accessToken) {
+        try {
+            return Jwts.parser()
+                    .setSigningKey(key)
+                    .build()
+                    .parseClaimsJws(accessToken)
+                    .getBody();
+        } catch (ExpiredJwtException e) {
+            return e.getClaims();
+        }
+    }
+
+}

--- a/src/main/java/com/dasom/MemoReal/global/security/CustomUserDetails.java
+++ b/src/main/java/com/dasom/MemoReal/global/security/CustomUserDetails.java
@@ -1,0 +1,54 @@
+//package com.dasom.MemoReal.global.security;
+//
+//import lombok.RequiredArgsConstructor;
+//import org.springframework.security.core.GrantedAuthority;
+//import org.springframework.security.core.userdetails.UserDetails;
+//
+//import java.util.ArrayList;
+//import java.util.Collection;
+//import java.util.List;
+//
+//@RequiredArgsConstructor
+//public class CustomUserDetails implements UserDetails {
+//
+//    private final User user;
+//
+//    @Override
+//    public Collection<? extends GrantedAuthority> getAuthorities() {
+//        Collection<GrantedAuthority> collection = new ArrayList<>();
+//
+//        collection.add(() -> user.getRole());
+//
+//        return collection;
+//    }
+//
+//    @Override
+//    public String getPassword() {
+//        return user.getPassword();
+//    }
+//
+//    @Override
+//    public String getUsername() {
+//        return user.getUsername();
+//    }
+//
+//    @Override
+//    public boolean isAccountNonExpired() {
+//        return true;
+//    }
+//
+//    @Override
+//    public boolean isAccountNonLocked() {
+//        return true;
+//    }
+//
+//    @Override
+//    public boolean isCredentialsNonExpired() {
+//        return true;
+//    }
+//
+//    @Override
+//    public boolean isEnabled() {
+//        return true;
+//    }
+//}

--- a/src/main/java/com/dasom/MemoReal/global/security/CustomUserDetailsService.java
+++ b/src/main/java/com/dasom/MemoReal/global/security/CustomUserDetailsService.java
@@ -1,0 +1,36 @@
+package com.dasom.MemoReal.global.security;
+
+import com.dasom.MemoReal.domain.user.entity.User;
+import com.dasom.MemoReal.domain.user.repository.UserRepository;
+import com.dasom.MemoReal.global.exception.CustomException;
+import com.dasom.MemoReal.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class CustomUserDetailsService implements UserDetailsService {
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    @Override
+    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+        return userRepository.findByEmail(email)
+                .map(this::createUserDetails)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+    }
+
+    // 해당하는 User 의 데이터가 존재한다면 UserDetails 객체로 만들어서 return
+    private UserDetails createUserDetails(User user) {
+        return User.builder()
+                .username(user.getUsername())
+                .password(user.getPassword())
+                .roles(user.getRoles()) //  .roles(member.getRoles().toArray(new String[0])) 사용시 에러남 임시조치 ?
+                .build();
+    }
+}

--- a/src/main/java/com/dasom/MemoReal/global/security/config/SecurityConfig.java
+++ b/src/main/java/com/dasom/MemoReal/global/security/config/SecurityConfig.java
@@ -1,0 +1,51 @@
+package com.dasom.MemoReal.global.security.config;
+
+import com.dasom.MemoReal.global.jwt.filter.JwtAuthenticationFilter;
+import com.dasom.MemoReal.global.jwt.provider.JwtTokenProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity httpSecurity) throws Exception {
+        return httpSecurity
+                .httpBasic(httpBasic -> httpBasic.disable())
+                .csrf(csrf -> csrf.disable())
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/", "/join", "/login").permitAll()
+                        .anyRequest().authenticated()
+                )
+                .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider), UsernamePasswordAuthenticationFilter.class)
+                .build();
+    }
+
+    @Bean
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration configuration) throws Exception {
+        return configuration.getAuthenticationManager();
+    }
+
+    @Bean
+    public BCryptPasswordEncoder bCryptPasswordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+
+}
+
+

--- a/src/main/java/com/dasom/MemoReal/global/security/util/SecurityUtil.java
+++ b/src/main/java/com/dasom/MemoReal/global/security/util/SecurityUtil.java
@@ -1,0 +1,14 @@
+package com.dasom.MemoReal.global.security.util;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+public class SecurityUtil {
+    public static String getCurrentUsername() {
+        final Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null || authentication.getName() == null) {
+            throw new RuntimeException("No authentication information.");
+        }
+        return authentication.getName();
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -10,6 +10,9 @@ spring:
     username: ${DB_USERNAME}
     password: ${DB_PASSWORD}
 
+  jwt:
+    secret: ${JWT_SECRET}
+
   jpa:
     hibernate:
       ddl-auto: update


### PR DESCRIPTION
# [feat] Jwt, Security  설정 및 사용자 정의 예외처리 구현

## 😺 Issue
- #13 

## ✅ 작업 리스트
- jwt, security 기능 구현

## ⚙️ 작업 내용
- 사용자 정의 예외 추가 (#9 코드 이용)
- security 설정
- jwt 설정
- 회원가입 추가
- 로그인 시 토큰 발행
- Jwt DTO, UserDTO, JoinDTO, LoginDTO 추가

## 📷 테스트 / 구현 내용

- 로그인시 토큰 발행
<img width="1737" height="957" alt="image" src="https://github.com/user-attachments/assets/cf71227b-47f5-4814-b696-83877ff0fb2b" />

- 테스트 시간이 부족하여 간단한 컨트롤러 url로 대체
- 이메일과 비밀번호로 로그인 (토큰정보 포함)시 해당 유저 닉네임이 반환되도록 테스트함

<img width="993" height="976" alt="image" src="https://github.com/user-attachments/assets/6ba3b07e-6815-4cdd-a18b-bfb9a429766b" />


## 참고 사항 (필요 시)
- [Security + Jwt 참고](https://suddiyo.tistory.com/entry/Spring-Spring-Security-JWT-%EB%A1%9C%EA%B7%B8%EC%9D%B8-%EA%B5%AC%ED%98%84%ED%95%98%EA%B8%B0-1)

