### PR TITLE
[feat] IPFS 연동을 통한 캡슐 컨텐츠 업로드 및 메타데이터 저장

### DIFF
--- a/src/main/java/com/dasom/MemoReal/domain/Capsule/controller/ContentController.java
+++ b/src/main/java/com/dasom/MemoReal/domain/Capsule/controller/ContentController.java
@@ -57,4 +57,11 @@ public class ContentController {
         String message = contentService.updateMetadataFields(id, updates);
         return ResponseEntity.ok(message);
     }
+    @DeleteMapping("/delete/{metadataId}")
+    // Todo: JWT 연동 후 실제 유저 아이디로 변경
+    public ResponseEntity<String> deleteContent(@PathVariable Long metadataId) {
+        Long userId = 1L; // TODO: JWT 연동 후 실제 유저 아이디로 변경
+        contentService.deleteMetadataAndContent(metadataId, userId);
+        return ResponseEntity.ok("메타데이터 및 IPFS 컨텐츠가 성공적으로 삭제되었습니다.");
+    }
 }

--- a/src/main/java/com/dasom/MemoReal/domain/Capsule/controller/ContentController.java
+++ b/src/main/java/com/dasom/MemoReal/domain/Capsule/controller/ContentController.java
@@ -1,0 +1,50 @@
+package com.dasom.MemoReal.domain.Capsule.controller;
+
+import com.dasom.MemoReal.domain.Capsule.dto.ContentUploadRequest;
+import com.dasom.MemoReal.domain.Capsule.dto.MetadataDto;
+import com.dasom.MemoReal.domain.Capsule.service.ContentService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/content")
+public class ContentController {
+
+    private final ContentService contentService;
+
+    @PostMapping("/upload")
+    public ResponseEntity<String> uploadContent(
+            @RequestPart("file") MultipartFile file,
+            @RequestPart("metadata") ContentUploadRequest metadata
+    ) {
+        Long userId = 1L; // TODO: JWT에서 추출 예정
+        MetadataDto savedMetadata = contentService.upload(file, metadata, userId);
+        return ResponseEntity.ok("정상적으로 업로드 되었습니다. 파일 해시: " + savedMetadata.getFileHash());
+    }
+
+    @GetMapping("/{id}") // 메타데이터 id를 받아서 상세정보 조회
+    public ResponseEntity<MetadataDto> getMetadata(@PathVariable Long id) {
+        MetadataDto dto = contentService.retrieveMetadata(id);
+        return ResponseEntity.ok(dto);
+    }
+
+    @GetMapping("/download/{id}") // 컨텐츠에 접근
+    public ResponseEntity<?> downloadFile(@PathVariable Long id) throws Exception {
+        byte[] fileData = contentService.downloadFile(id);
+        return ResponseEntity.ok()
+                .header("Content-Disposition", "attachment; filename=\"downloaded_file\"")
+                .body(fileData);
+    }
+
+    @GetMapping("/user/{userId}") // userid를 기반으로 해당 유저가 등록한 모든 메타데이터 조회
+    // Todo: JWT에서 userId 추출 예정
+    public ResponseEntity<List<MetadataDto>> getUserContent(@PathVariable Long userId) {
+        List<MetadataDto> list = contentService.findAllByUserId(userId);
+        return ResponseEntity.ok(list);
+    }
+}

--- a/src/main/java/com/dasom/MemoReal/domain/Capsule/controller/ContentController.java
+++ b/src/main/java/com/dasom/MemoReal/domain/Capsule/controller/ContentController.java
@@ -3,6 +3,8 @@ package com.dasom.MemoReal.domain.Capsule.controller;
 import com.dasom.MemoReal.domain.Capsule.dto.ContentUploadRequest;
 import com.dasom.MemoReal.domain.Capsule.dto.MetadataDto;
 import com.dasom.MemoReal.domain.Capsule.service.ContentService;
+import com.dasom.MemoReal.domain.user.service.UserService;
+import com.dasom.MemoReal.global.security.util.SecurityUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -17,18 +19,19 @@ import java.util.Map;
 public class ContentController {
 
     private final ContentService contentService;
+    private final UserService userService;
 
     @PostMapping("/upload")
     public ResponseEntity<String> uploadContent(
             @RequestPart("file") MultipartFile file,
             @RequestPart("metadata") ContentUploadRequest metadata
     ) {
-        Long userId = 1L; // TODO: JWT에서 추출 예정
+        Long userId = userService.getUserIdByUsername(SecurityUtil.getCurrentUsername());
         MetadataDto savedMetadata = contentService.upload(file, metadata, userId);
         return ResponseEntity.ok("정상적으로 업로드 되었습니다. 파일 해시: " + savedMetadata.getFileHash());
     }
 
-    @GetMapping("/{id}") // 메타데이터 id를 받아서 상세정보 조회
+    @GetMapping("/{id}")
     public ResponseEntity<MetadataDto> getMetadata(@PathVariable Long id) {
         MetadataDto dto = contentService.retrieveMetadata(id);
         return ResponseEntity.ok(dto);
@@ -36,31 +39,33 @@ public class ContentController {
 
     @GetMapping("/download/{id}")
     public ResponseEntity<?> downloadFile(@PathVariable Long id) {
-        byte[] fileData = contentService.downloadFile(id);
+        Long userId = userService.getUserIdByUsername(SecurityUtil.getCurrentUsername());
+        byte[] fileData = contentService.downloadFile(id, userId);
         return ResponseEntity.ok()
                 .header("Content-Disposition", "attachment; filename=\"downloaded_file\"")
                 .body(fileData);
     }
 
-    @GetMapping("/user/{userId}") // userid를 기반으로 해당 유저가 등록한 모든 메타데이터 조회
-    // Todo: JWT에서 userId 추출해서 사용하게 수정 할 예정
-    public ResponseEntity<List<MetadataDto>> getUserContent(@PathVariable Long userId) {
+    @GetMapping("/user")
+    public ResponseEntity<List<MetadataDto>> getUserContent() {
+        Long userId = userService.getUserIdByUsername(SecurityUtil.getCurrentUsername());
         List<MetadataDto> list = contentService.findAllByUserId(userId);
         return ResponseEntity.ok(list);
     }
+
     @PatchMapping("/{id}")
-    // Todo: JWT에서 userId 추출하여 메타데이터 상 등록된 대상과 같을 경우에만 실행 되게 수정
     public ResponseEntity<String> updateMetadataFields(
             @PathVariable Long id,
             @RequestBody Map<String, Object> updates
     ) {
-        String message = contentService.updateMetadataFields(id, updates);
+        Long userId = userService.getUserIdByUsername(SecurityUtil.getCurrentUsername());
+        String message = contentService.updateMetadataFields(id, updates, userId);
         return ResponseEntity.ok(message);
     }
+
     @DeleteMapping("/delete/{metadataId}")
-    // Todo: JWT 연동 후 실제 유저 아이디로 변경
     public ResponseEntity<String> deleteContent(@PathVariable Long metadataId) {
-        Long userId = 1L; // TODO: JWT 연동 후 실제 유저 아이디로 변경
+        Long userId = userService.getUserIdByUsername(SecurityUtil.getCurrentUsername());
         contentService.deleteMetadataAndContent(metadataId, userId);
         return ResponseEntity.ok("메타데이터 및 IPFS 컨텐츠가 성공적으로 삭제되었습니다.");
     }

--- a/src/main/java/com/dasom/MemoReal/domain/Capsule/controller/ContentController.java
+++ b/src/main/java/com/dasom/MemoReal/domain/Capsule/controller/ContentController.java
@@ -9,6 +9,7 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
+import java.util.Map;
 
 @RestController
 @RequiredArgsConstructor
@@ -33,8 +34,8 @@ public class ContentController {
         return ResponseEntity.ok(dto);
     }
 
-    @GetMapping("/download/{id}") // 컨텐츠에 접근
-    public ResponseEntity<?> downloadFile(@PathVariable Long id) throws Exception {
+    @GetMapping("/download/{id}")
+    public ResponseEntity<?> downloadFile(@PathVariable Long id) {
         byte[] fileData = contentService.downloadFile(id);
         return ResponseEntity.ok()
                 .header("Content-Disposition", "attachment; filename=\"downloaded_file\"")
@@ -42,9 +43,18 @@ public class ContentController {
     }
 
     @GetMapping("/user/{userId}") // userid를 기반으로 해당 유저가 등록한 모든 메타데이터 조회
-    // Todo: JWT에서 userId 추출 예정
+    // Todo: JWT에서 userId 추출해서 사용하게 수정 할 예정
     public ResponseEntity<List<MetadataDto>> getUserContent(@PathVariable Long userId) {
         List<MetadataDto> list = contentService.findAllByUserId(userId);
         return ResponseEntity.ok(list);
+    }
+    @PatchMapping("/{id}")
+    // Todo: JWT에서 userId 추출하여 메타데이터 상 등록된 대상과 같을 경우에만 실행 되게 수정
+    public ResponseEntity<String> updateMetadataFields(
+            @PathVariable Long id,
+            @RequestBody Map<String, Object> updates
+    ) {
+        String message = contentService.updateMetadataFields(id, updates);
+        return ResponseEntity.ok(message);
     }
 }

--- a/src/main/java/com/dasom/MemoReal/domain/Capsule/dto/ContentUploadRequest.java
+++ b/src/main/java/com/dasom/MemoReal/domain/Capsule/dto/ContentUploadRequest.java
@@ -7,6 +7,7 @@ import java.time.LocalDate;
 
 @Data
 @NoArgsConstructor
+@Builder
 @AllArgsConstructor
 public class ContentUploadRequest {
 

--- a/src/main/java/com/dasom/MemoReal/domain/Capsule/dto/ContentUploadRequest.java
+++ b/src/main/java/com/dasom/MemoReal/domain/Capsule/dto/ContentUploadRequest.java
@@ -1,0 +1,34 @@
+package com.dasom.MemoReal.domain.Capsule.dto;
+
+import com.dasom.MemoReal.domain.Capsule.entity.Metadata;
+import lombok.*;
+
+import java.time.LocalDate;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class ContentUploadRequest {
+
+    private String title;
+    private String description;
+    private String accessCondition;
+    private String category;
+    private String tags;
+
+
+    public Metadata toEntity(String filename, String contentType, String ipfsContentHash, LocalDate uploadedDate, Long userId) {
+        return Metadata.builder()
+                .filename(filename)
+                .contentType(contentType)
+                .title(this.title)
+                .description(this.description)
+                .accessCondition(this.accessCondition)
+                .category(this.category)
+                .tags(this.tags)
+                .uploadedDate(uploadedDate)
+                .ipfsContentHash(ipfsContentHash)
+                .userId(userId)
+                .build();
+    }
+}

--- a/src/main/java/com/dasom/MemoReal/domain/Capsule/dto/MetadataDto.java
+++ b/src/main/java/com/dasom/MemoReal/domain/Capsule/dto/MetadataDto.java
@@ -1,0 +1,35 @@
+package com.dasom.MemoReal.domain.Capsule.dto;
+
+import com.dasom.MemoReal.domain.Capsule.entity.Metadata;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class MetadataDto {
+    private String filename;
+    private String contentType; //확장자
+    private String title;
+    private String description;
+    private String uploadedDate;      // yyyy-MM-dd
+    private String fileHash;          // 실제 콘텐츠 파일의 IPFS 해시
+    private String accessCondition;   // 열람 조건
+    private String category;  //컨텐츠 분류 용 카테고리
+    private String tags;
+
+    public static MetadataDto fromEntity(Metadata metadata) {
+        return new MetadataDto(
+                metadata.getFilename(),
+                metadata.getContentType(),
+                metadata.getTitle(),
+                metadata.getDescription(),
+                metadata.getUploadedDate() != null ? metadata.getUploadedDate().toString() : null,
+                metadata.getIpfsContentHash(),
+                metadata.getAccessCondition(),
+                metadata.getCategory(),
+                metadata.getTags()
+        );
+    }
+}

--- a/src/main/java/com/dasom/MemoReal/domain/Capsule/dto/MetadataDto.java
+++ b/src/main/java/com/dasom/MemoReal/domain/Capsule/dto/MetadataDto.java
@@ -9,6 +9,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class MetadataDto {
+    private Long id;// 테스트용 필드
     private String filename;
     private String contentType; //확장자
     private String title;
@@ -21,6 +22,7 @@ public class MetadataDto {
 
     public static MetadataDto fromEntity(Metadata metadata) {
         return new MetadataDto(
+                metadata.getId(),
                 metadata.getFilename(),
                 metadata.getContentType(),
                 metadata.getTitle(),
@@ -32,4 +34,5 @@ public class MetadataDto {
                 metadata.getTags()
         );
     }
+
 }

--- a/src/main/java/com/dasom/MemoReal/domain/Capsule/entity/Metadata.java
+++ b/src/main/java/com/dasom/MemoReal/domain/Capsule/entity/Metadata.java
@@ -1,0 +1,33 @@
+package com.dasom.MemoReal.domain.Capsule.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Table(name = "metadata")
+@Entity
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Metadata {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String ipfsContentHash;
+    private String filename;
+    private String contentType;
+    private String title;
+    private String description;
+    private LocalDate uploadedDate;
+    private String accessCondition;
+    private String category;
+    private String tags;
+    private Long userId;// 추후에 user 테이블과 외래키 연결
+}

--- a/src/main/java/com/dasom/MemoReal/domain/Capsule/repository/MetadataRepository.java
+++ b/src/main/java/com/dasom/MemoReal/domain/Capsule/repository/MetadataRepository.java
@@ -1,0 +1,11 @@
+package com.dasom.MemoReal.domain.Capsule.repository;
+
+import com.dasom.MemoReal.domain.Capsule.entity.Metadata;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface MetadataRepository extends JpaRepository<Metadata, Long> {
+    List<Metadata> findAllByUserId(Long userId); // 유저별 메타데이터 조회
+
+}

--- a/src/main/java/com/dasom/MemoReal/domain/Capsule/service/ContentService.java
+++ b/src/main/java/com/dasom/MemoReal/domain/Capsule/service/ContentService.java
@@ -37,7 +37,7 @@ public class ContentService {
             tempFile = File.createTempFile("upload-", file.getOriginalFilename());
             file.transferTo(tempFile.toPath());
 
-            IpfsUploadResult ipfsResult = ipfsClient.upload(tempFile);
+            IpfsUploadResult ipfsResult = ipfsClient.uploadToMfs(tempFile);
 
             Metadata metadata = request.toEntity(
                     ipfsResult.getFileName(),
@@ -85,8 +85,14 @@ public class ContentService {
             throw new CustomException(ErrorCode.ACCESS_DENIED);
         }
 
-        return ipfsClient.download(metadata.getIpfsContentHash());
+        // 현재는 MFS 내 저장된 파일명을 기반으로 다운로드
+        // 추후 해시(IPFS content hash) 기반으로 다운로드 기능 개선 예정
+        return ipfsClient.downloadFromMfs(metadata.getFilename());
+
+        // 아래는 해시 기반 다운로드 시 사용 예시 (미구현)
+        // return ipfsClient.downloadByHash(metadata.getIpfsContentHash());
     }
+
 
     public List<MetadataDto> findAllByUserId(Long userId) {
         if (userId == null) {
@@ -160,7 +166,7 @@ public class ContentService {
         }
 
         try {
-            ipfsClient.unpinAndGc(metadata.getIpfsContentHash());
+            ipfsClient.deleteFromMfs(metadata.getIpfsContentHash());
         } catch (Exception e) {
             throw new CustomException(ErrorCode.CONTENT_DELETE_FAILED, "IPFS에서 컨텐츠 삭제 실패: " + e.getMessage());
         }

--- a/src/main/java/com/dasom/MemoReal/domain/Capsule/service/ContentService.java
+++ b/src/main/java/com/dasom/MemoReal/domain/Capsule/service/ContentService.java
@@ -1,0 +1,112 @@
+package com.dasom.MemoReal.domain.Capsule.service;
+
+import com.dasom.MemoReal.domain.Capsule.dto.ContentUploadRequest;
+import com.dasom.MemoReal.domain.Capsule.dto.MetadataDto;
+import com.dasom.MemoReal.domain.Capsule.entity.Metadata;
+import com.dasom.MemoReal.domain.Capsule.repository.MetadataRepository;
+import com.dasom.MemoReal.global.exception.CustomException;
+import com.dasom.MemoReal.global.exception.ErrorCode;
+import com.dasom.MemoReal.global.ipfs.IpfsUploader;
+import com.dasom.MemoReal.global.ipfs.dto.IpfsUploadResult;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class ContentService {
+
+    private final MetadataRepository repository;
+    private final IpfsUploader ipfsUploader;
+
+    public MetadataDto upload(MultipartFile file, ContentUploadRequest request, Long userId) {
+        if (userId == null) {
+            throw new CustomException(ErrorCode.USER_ID_NOT_FOUND);
+        }
+        File tempFile = null;
+        try {
+            // MultipartFile을 임시 파일로 저장
+            tempFile = File.createTempFile("upload-", file.getOriginalFilename());
+            file.transferTo(tempFile.toPath());
+
+            // IPFS에 업로드
+            IpfsUploadResult ipfsResult = ipfsUploader.upload(tempFile);
+
+            // Metadata 엔티티 생성 및 저장
+            Metadata metadata = request.toEntity(
+                    ipfsResult.getFileName(),
+                    file.getContentType(),
+                    ipfsResult.getHash(),
+                    LocalDate.now(),
+                    userId
+            );
+            repository.save(metadata);
+
+            // 저장된 메타데이터를 DTO로 변환 후 반환
+            return MetadataDto.fromEntity(metadata);
+
+        } catch (IOException e) {
+            throw new CustomException(ErrorCode.UPLOAD_FAILED, "파일 처리 중 오류 발생: " + e.getMessage());
+
+        } finally {
+            // 업로드 후 임시 파일 삭제
+            if (tempFile != null && tempFile.exists()) {
+                boolean deleted = tempFile.delete();
+                if (!deleted) {
+                    System.err.println("임시 파일 삭제 실패: " + tempFile.getAbsolutePath());
+                }
+            }
+        }
+    }
+
+    // 메타데이터 조회
+    public MetadataDto retrieveMetadata(Long id) {
+        Metadata metadata = repository.findById(id)
+                .orElseThrow(() -> new CustomException(ErrorCode.METADATA_NOT_FOUND, "메타데이터를 찾을 수 없습니다. ID: " + id));
+
+        return MetadataDto.fromEntity(metadata);
+    }
+
+    // 파일 다운로드 (mocked)
+    public byte[] downloadFile(Long id) throws Exception {
+        Metadata metadata = repository.findById(id)
+                .orElseThrow(() -> new CustomException(ErrorCode.METADATA_NOT_FOUND, "메타데이터를 찾을 수 없습니다. ID: " + id));
+
+        MetadataDto dto = MetadataDto.fromEntity(metadata);
+
+        LocalDate accessDate = LocalDate.parse(dto.getAccessCondition());
+        if (LocalDate.now().isBefore(accessDate)) {
+            throw new CustomException(ErrorCode.ACCESS_DENIED);
+        }
+
+        Path mockPath = Path.of("/tmp/mock-decrypted/" + metadata.getIpfsContentHash());
+        if (!Files.exists(mockPath)) {
+            throw new CustomException(ErrorCode.FILE_NOT_FOUND);
+        }
+
+        return Files.readAllBytes(mockPath);
+    }
+
+    public List<MetadataDto> findAllByUserId(Long userId) {
+        if (userId == null) {
+            throw new CustomException(ErrorCode.USER_ID_NOT_FOUND);
+        }
+        List<Metadata> metadataList = repository.findAllByUserId(userId);
+
+        if (metadataList == null) {
+            throw new CustomException(ErrorCode.METADATA_NOT_FOUND,
+                    "해당 유저의 메타데이터를 조회할 수 없습니다. userId: " + userId);
+        }
+        return metadataList.stream()
+                .map(MetadataDto::fromEntity)
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/dasom/MemoReal/domain/Capsule/service/ContentService.java
+++ b/src/main/java/com/dasom/MemoReal/domain/Capsule/service/ContentService.java
@@ -102,19 +102,13 @@ public class ContentService {
             throw new CustomException(ErrorCode.ACCESS_DENIED,"메타데이터의 소유자가 아님");
         }
 
-        List<String> allowedFields = List.of("filename", "contentType", "title", "description", "category", "tags");
+        List<String> allowedFields = List.of("title", "description", "category", "tags");
 
         List<String> ignoredFields = new ArrayList<>();
 
         updates.forEach((key, value) -> {
             if (allowedFields.contains(key)) {
                 switch (key) {
-                    case "filename":
-                        metadata.setFilename((String) value);
-                        break;
-                    case "contentType":
-                        metadata.setContentType((String) value);
-                        break;
                     case "title":
                         metadata.setTitle((String) value);
                         break;

--- a/src/main/java/com/dasom/MemoReal/domain/Capsule/service/ContentService.java
+++ b/src/main/java/com/dasom/MemoReal/domain/Capsule/service/ContentService.java
@@ -12,7 +12,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.io.File;
 import java.io.IOException;
 import java.time.LocalDate;
 import java.util.ArrayList;
@@ -32,12 +31,12 @@ public class ContentService {
         if (userId == null) {
             throw new CustomException(ErrorCode.USER_ID_NOT_FOUND);
         }
-        File tempFile = null;
-        try {
-            tempFile = File.createTempFile("upload-", file.getOriginalFilename());
-            file.transferTo(tempFile.toPath());
 
-            IpfsUploadResult ipfsResult = ipfsClient.uploadToMfs(tempFile);
+        try {
+            byte[] contentBytes = file.getBytes();
+
+            //(pin=false 옵션은 클라이언트 내부 처리)
+            IpfsUploadResult ipfsResult = ipfsClient.upload(contentBytes, file.getOriginalFilename());
 
             Metadata metadata = request.toEntity(
                     ipfsResult.getFileName(),
@@ -52,14 +51,6 @@ public class ContentService {
 
         } catch (IOException e) {
             throw new CustomException(ErrorCode.UPLOAD_FAILED, "파일 처리 중 오류 발생: " + e.getMessage());
-
-        } finally {
-            if (tempFile != null && tempFile.exists()) {
-                boolean deleted = tempFile.delete();
-                if (!deleted) {
-                    System.err.println("임시 파일 삭제 실패: " + tempFile.getAbsolutePath());
-                }
-            }
         }
     }
 
@@ -78,19 +69,13 @@ public class ContentService {
             throw new CustomException(ErrorCode.ACCESS_DENIED,"해당 메타데이터의 소유자가 아님");
         }
 
-        MetadataDto dto = MetadataDto.fromEntity(metadata);
-
-        LocalDate accessDate = LocalDate.parse(dto.getAccessCondition());
+        LocalDate accessDate = LocalDate.parse(metadata.getAccessCondition());
         if (LocalDate.now().isBefore(accessDate)) {
             throw new CustomException(ErrorCode.ACCESS_DENIED);
         }
 
-        // 현재는 MFS 내 저장된 파일명을 기반으로 다운로드
-        // 추후 해시(IPFS content hash) 기반으로 다운로드 기능 개선 예정
-        return ipfsClient.downloadFromMfs(metadata.getFilename());
-
-        // 아래는 해시 기반 다운로드 시 사용 예시 (미구현)
-        // return ipfsClient.downloadByHash(metadata.getIpfsContentHash());
+        // 해시 기반 다운로드
+        return ipfsClient.downloadByHash(metadata.getIpfsContentHash());
     }
 
 
@@ -166,7 +151,7 @@ public class ContentService {
         }
 
         try {
-            ipfsClient.deleteFromMfs(metadata.getIpfsContentHash());
+            ipfsClient.deleteByHash(metadata.getIpfsContentHash());
         } catch (Exception e) {
             throw new CustomException(ErrorCode.CONTENT_DELETE_FAILED, "IPFS에서 컨텐츠 삭제 실패: " + e.getMessage());
         }

--- a/src/main/java/com/dasom/MemoReal/domain/user/service/UserService.java
+++ b/src/main/java/com/dasom/MemoReal/domain/user/service/UserService.java
@@ -2,8 +2,9 @@ package com.dasom.MemoReal.domain.user.service;
 
 import com.dasom.MemoReal.domain.user.dto.JoinDTO;
 import com.dasom.MemoReal.domain.user.dto.UserDTO;
-import com.dasom.MemoReal.domain.user.entity.User;
 import com.dasom.MemoReal.domain.user.repository.UserRepository;
+import com.dasom.MemoReal.global.exception.CustomException;
+import com.dasom.MemoReal.global.exception.ErrorCode;
 import com.dasom.MemoReal.global.jwt.dto.JwtTokenDTO;
 import com.dasom.MemoReal.global.jwt.provider.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
@@ -52,7 +53,11 @@ public class UserService {
         roles.add("USER");  // USER 권한 부여
         return UserDTO.toDto(userRepository.save(signUpDto.toEntity(encodedPassword, roles)));
     }
-
+    public Long getUserIdByUsername(String username) {
+        return userRepository.findByUsername(username)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND))
+                .getId();
+    }
     @PostMapping("/test")
     public String test() {
         return "success";

--- a/src/main/java/com/dasom/MemoReal/global/exception/ErrorCode.java
+++ b/src/main/java/com/dasom/MemoReal/global/exception/ErrorCode.java
@@ -10,6 +10,7 @@ public enum ErrorCode {
     DUPLICATE_EMAIL("USER_002", HttpStatus.CONFLICT, "이미 존재하는 이메일입니다."),
     USER_UPDATE_NOT_FOUND("USER_003", HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),
     INVALID_UPDATE_FIELD("USER_004", HttpStatus.BAD_REQUEST, "수정할 수 없는 필드입니다."),
+    USER_ID_NOT_FOUND("USER_005", HttpStatus.NOT_FOUND, "유저 아이디를 찾을 수 없습니다."),
 
     // 사용자 로그인 관련 에러
     USER_NOT_FOUND("AUTH_001", HttpStatus.NOT_FOUND, "이메일이 존재하지 않습니다."),
@@ -18,7 +19,14 @@ public enum ErrorCode {
     // 일반적인 에러(유효성 검사 등)
     INVALID_INPUT_VALUE("COMMON_001", HttpStatus.BAD_REQUEST, "유효하지 않은 입력 값입니다."),
     UNAUTHORIZED("COMMON_002", HttpStatus.UNAUTHORIZED, "인증되지 않은 접근입니다."),
-    INTERNAL_SERVER_ERROR("COMMON_999", HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류가 발생했습니다.");
+    INTERNAL_SERVER_ERROR("COMMON_999", HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류가 발생했습니다."),
+
+    // 콘텐츠 관련 에러
+    METADATA_NOT_FOUND("CONTENT_001", HttpStatus.NOT_FOUND, "메타데이터를 찾을 수 없습니다."),
+    FILE_NOT_FOUND("CONTENT_002", HttpStatus.NOT_FOUND, "요청한 파일을 찾을 수 없습니다."),
+    ACCESS_DENIED("CONTENT_003", HttpStatus.FORBIDDEN, "열람 조건을 만족하지 못했습니다."),
+    UPLOAD_FAILED("CONTENT_004", HttpStatus.INTERNAL_SERVER_ERROR, "컨텐츠 업로드에 실패했습니다."),
+    INVALID_INPUT("CONTENT_005", HttpStatus.BAD_REQUEST, "유효하지 않은 입력 값입니다.");
 
     private final String code;
     private final HttpStatus httpStatus;

--- a/src/main/java/com/dasom/MemoReal/global/exception/ErrorCode.java
+++ b/src/main/java/com/dasom/MemoReal/global/exception/ErrorCode.java
@@ -26,8 +26,8 @@ public enum ErrorCode {
     FILE_NOT_FOUND("CONTENT_002", HttpStatus.NOT_FOUND, "요청한 파일을 찾을 수 없습니다."),
     ACCESS_DENIED("CONTENT_003", HttpStatus.FORBIDDEN, "열람 조건을 만족하지 못했습니다."),
     UPLOAD_FAILED("CONTENT_004", HttpStatus.INTERNAL_SERVER_ERROR, "컨텐츠 업로드에 실패했습니다."),
-    INVALID_INPUT("CONTENT_005", HttpStatus.BAD_REQUEST, "유효하지 않은 입력 값입니다.");
-
+    INVALID_INPUT("CONTENT_005", HttpStatus.BAD_REQUEST, "유효하지 않은 입력 값입니다."),
+    CONTENT_DELETE_FAILED("CONTENT_006",HttpStatus.INTERNAL_SERVER_ERROR ,"컨텐츠 삭제 실패");
     private final String code;
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/dasom/MemoReal/global/exception/ErrorCode.java
+++ b/src/main/java/com/dasom/MemoReal/global/exception/ErrorCode.java
@@ -27,7 +27,8 @@ public enum ErrorCode {
     ACCESS_DENIED("CONTENT_003", HttpStatus.FORBIDDEN, "열람 조건을 만족하지 못했습니다."),
     UPLOAD_FAILED("CONTENT_004", HttpStatus.INTERNAL_SERVER_ERROR, "컨텐츠 업로드에 실패했습니다."),
     INVALID_INPUT("CONTENT_005", HttpStatus.BAD_REQUEST, "유효하지 않은 입력 값입니다."),
-    CONTENT_DELETE_FAILED("CONTENT_006",HttpStatus.INTERNAL_SERVER_ERROR ,"컨텐츠 삭제 실패");
+    CONTENT_DELETE_FAILED("CONTENT_006",HttpStatus.INTERNAL_SERVER_ERROR ,"컨텐츠 삭제 실패"),
+    CONTENT_DOWNLOAD_FAILED("CONTENT_007",HttpStatus.INTERNAL_SERVER_ERROR ,"컨텐츠 다운로드 실패");
     private final String code;
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/dasom/MemoReal/global/ipfs/IpfsClient.java
+++ b/src/main/java/com/dasom/MemoReal/global/ipfs/IpfsClient.java
@@ -76,7 +76,28 @@ public class IpfsClient {
             throw new CustomException(ErrorCode.FILE_NOT_FOUND, "IPFS 요청 실패: " + e.getMessage());
         }
     }
+    public void unpinAndGc(String ipfsHash) {
+        try {
+            ProcessBuilder unpinBuilder = new ProcessBuilder("ipfs", "pin", "rm", ipfsHash);
+            Process unpin = unpinBuilder.start();
+            int unpinExit = unpin.waitFor();
 
+            if (unpinExit != 0) {
+                throw new RuntimeException("IPFS pin 제거 실패");
+            }
+
+            ProcessBuilder gcBuilder = new ProcessBuilder("ipfs", "repo", "gc");
+            Process gc = gcBuilder.start();
+            int gcExit = gc.waitFor();
+
+            if (gcExit != 0) {
+                throw new RuntimeException("IPFS repo gc 실패");
+            }
+
+        } catch (Exception e) {
+            throw new RuntimeException("IPFS 삭제 과정 중 오류 발생: " + e.getMessage(), e);
+        }
+    }
     // 간단한 JSON 값 파싱
     private String extractValue(String json, String key) {
         int start = json.indexOf("\"" + key + "\":\"") + key.length() + 4;

--- a/src/main/java/com/dasom/MemoReal/global/ipfs/IpfsClient.java
+++ b/src/main/java/com/dasom/MemoReal/global/ipfs/IpfsClient.java
@@ -3,6 +3,7 @@ package com.dasom.MemoReal.global.ipfs;
 import com.dasom.MemoReal.global.exception.CustomException;
 import com.dasom.MemoReal.global.exception.ErrorCode;
 import com.dasom.MemoReal.global.ipfs.dto.IpfsUploadResult;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.io.FileSystemResource;
 import org.springframework.http.*;
 import org.springframework.stereotype.Component;
@@ -15,93 +16,122 @@ import java.io.File;
 @Component
 public class IpfsClient {
 
-    private static final String IPFS_API_BASE_URL = "http://localhost:5001/api/v0";
+    @Value("${ipfs.api-base-url}")
+    private String ipfsApiBaseUrl;
+
+    private final String MFS_BASE_PATH = "/test"; // MFS 폴더 경로
+
+    // RestTemplate 재사용용 필드
+    private final RestTemplate restTemplate = new RestTemplate();
 
     /**
-     * IPFS에 파일 업로드
-     * @param file 업로드할 파일
-     * @return 업로드 결과 객체 (해시, 파일명, 크기)
+     * MFS의 /test 폴더 아래에 파일 업로드
      */
-    public IpfsUploadResult upload(File file) {
-        try {
-            RestTemplate restTemplate = new RestTemplate();
+    public IpfsUploadResult uploadToMfs(File file) {
+        String mfsPath = MFS_BASE_PATH + "/" + file.getName();
+        String url = ipfsApiBaseUrl + "/files/write?arg=" + mfsPath + "&create=true&truncate=true";
 
-            MultiValueMap<String, Object> body = new LinkedMultiValueMap<>();
-            body.add("file", new FileSystemResource(file));
+        // multipart/form-data 구성
+        MultiValueMap<String, Object> body = new LinkedMultiValueMap<>();
+        // Resource로 감싸서 전송
+        body.add("file", new FileSystemResource(file));
 
-            HttpHeaders headers = new HttpHeaders();
-            headers.setContentType(MediaType.MULTIPART_FORM_DATA);
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.MULTIPART_FORM_DATA);
 
-            HttpEntity<MultiValueMap<String, Object>> requestEntity = new HttpEntity<>(body, headers);
+        HttpEntity<MultiValueMap<String, Object>> requestEntity = new HttpEntity<>(body, headers);
 
-            ResponseEntity<String> response = restTemplate.postForEntity(
-                    IPFS_API_BASE_URL + "/add",
-                    requestEntity,
-                    String.class
-            );
+        ResponseEntity<String> writeResponse = restTemplate.postForEntity(url, requestEntity, String.class);
 
-            if (response.getStatusCode().is2xxSuccessful()) {
-                String bodyStr = response.getBody();
-                if (bodyStr != null && bodyStr.contains("Hash")) {
-                    String hash = extractValue(bodyStr, "Hash");
-                    String name = extractValue(bodyStr, "Name");
-                    String size = extractValue(bodyStr, "Size");
-                    return new IpfsUploadResult(hash, name, Long.parseLong(size));
-                }
-            }
-            throw new CustomException(ErrorCode.UPLOAD_FAILED, "IPFS 응답 실패: " + response.getStatusCode());
-        } catch (Exception e) {
-            throw new CustomException(ErrorCode.UPLOAD_FAILED, "IPFS 요청 실패: " + e.getMessage());
+        if (!writeResponse.getStatusCode().is2xxSuccessful()) {
+            throw new CustomException(ErrorCode.UPLOAD_FAILED, "MFS 파일 쓰기 실패: " + writeResponse.getStatusCode());
         }
+
+        // 파일 상태 조회는 기존 코드 유지
+        String statUrl = ipfsApiBaseUrl + "/files/stat?arg=" + mfsPath;
+        ResponseEntity<String> statResponse = restTemplate.postForEntity(statUrl, null, String.class);
+        if (!statResponse.getStatusCode().is2xxSuccessful()) {
+            throw new CustomException(ErrorCode.UPLOAD_FAILED, "MFS 파일 상태 조회 실패: " + statResponse.getStatusCode());
+        }
+
+        String bodyStr = statResponse.getBody();
+        if (bodyStr == null) {
+            throw new CustomException(ErrorCode.UPLOAD_FAILED, "MFS 파일 상태 응답 없음");
+        }
+
+        String hash = extractHashFromJson(bodyStr);
+
+        return new IpfsUploadResult(hash, file.getName(), file.length());
+
     }
 
     /**
-     * IPFS 해시로부터 파일 데이터 다운로드
-     * @param ipfsHash IPFS 파일 해시
-     * @return 파일 데이터 바이트 배열
+     * MFS 내 /test 폴더에 저장된 파일 다운로드
      */
-    public byte[] download(String ipfsHash) {
+    public byte[] downloadFromMfs(String filename) {
         try {
-            RestTemplate restTemplate = new RestTemplate();
-            String url = IPFS_API_BASE_URL + "/cat?arg=" + ipfsHash;
+            if (filename == null || filename.trim().isEmpty() || filename.endsWith("/")) {
+                throw new CustomException(ErrorCode.FILE_NOT_FOUND, "유효하지 않은 파일명입니다: " + filename);
+            }
 
-            ResponseEntity<byte[]> response = restTemplate.getForEntity(url, byte[].class);
+            if (!filename.startsWith("/")) {
+                filename = "/" + filename;
+            }
+
+            String targetPath = MFS_BASE_PATH + filename; // "/test/filename"
+
+            String url = ipfsApiBaseUrl + "/files/read?arg=" + targetPath;
+
+            HttpHeaders headers = new HttpHeaders();
+            headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+            HttpEntity<String> entity = new HttpEntity<>("", headers);
+
+            ResponseEntity<byte[]> response = restTemplate.exchange(
+                    url,
+                    HttpMethod.POST,  // GET이 아닌 POST로 변경해야 함
+                    entity,
+                    byte[].class
+            );
 
             if (response.getStatusCode() == HttpStatus.OK) {
                 return response.getBody();
             } else {
-                throw new CustomException(ErrorCode.FILE_NOT_FOUND, "IPFS 파일 다운로드 실패: " + response.getStatusCode());
+                throw new CustomException(ErrorCode.FILE_NOT_FOUND, "MFS 파일 다운로드 실패: " + response.getStatusCode());
             }
         } catch (Exception e) {
-            throw new CustomException(ErrorCode.FILE_NOT_FOUND, "IPFS 요청 실패: " + e.getMessage());
+            throw new CustomException(ErrorCode.FILE_NOT_FOUND, "MFS 요청 실패: " + e.getMessage());
         }
     }
-    public void unpinAndGc(String ipfsHash) {
+
+
+
+    /**
+     * MFS 내 /test 폴더에 저장된 파일 삭제
+     */
+    public void deleteFromMfs(String filename) {
         try {
-            ProcessBuilder unpinBuilder = new ProcessBuilder("ipfs", "pin", "rm", ipfsHash);
-            Process unpin = unpinBuilder.start();
-            int unpinExit = unpin.waitFor();
+            String targetPath = MFS_BASE_PATH + "/" + filename;
+            String url = ipfsApiBaseUrl + "/files/rm?arg=" + targetPath;
 
-            if (unpinExit != 0) {
-                throw new RuntimeException("IPFS pin 제거 실패");
+            ResponseEntity<String> response = restTemplate.postForEntity(url, null, String.class);
+
+            if (!response.getStatusCode().is2xxSuccessful()) {
+                throw new CustomException(ErrorCode.CONTENT_DELETE_FAILED, "MFS 파일 삭제 실패: " + response.getStatusCode());
             }
-
-            ProcessBuilder gcBuilder = new ProcessBuilder("ipfs", "repo", "gc");
-            Process gc = gcBuilder.start();
-            int gcExit = gc.waitFor();
-
-            if (gcExit != 0) {
-                throw new RuntimeException("IPFS repo gc 실패");
-            }
-
         } catch (Exception e) {
-            throw new RuntimeException("IPFS 삭제 과정 중 오류 발생: " + e.getMessage(), e);
+            throw new CustomException(ErrorCode.CONTENT_DELETE_FAILED, "MFS 삭제 실패: " + e.getMessage());
         }
     }
-    // 간단한 JSON 값 파싱
-    private String extractValue(String json, String key) {
-        int start = json.indexOf("\"" + key + "\":\"") + key.length() + 4;
+
+    /**
+     * 간단한 JSON 문자열에서 "Hash" 키의 값을 추출하는 메서드
+     */
+    private String extractHashFromJson(String json) {
+        // "Hash":"Qm..." 형태에서 값만 추출
+        int start = json.indexOf("\"Hash\":\"") + 7; // "Hash":" 길이 = 7
         int end = json.indexOf("\"", start);
+        if (start < 7 || end < 0) return "";
         return json.substring(start, end);
     }
 }

--- a/src/main/java/com/dasom/MemoReal/global/ipfs/IpfsClient.java
+++ b/src/main/java/com/dasom/MemoReal/global/ipfs/IpfsClient.java
@@ -3,15 +3,18 @@ package com.dasom.MemoReal.global.ipfs;
 import com.dasom.MemoReal.global.exception.CustomException;
 import com.dasom.MemoReal.global.exception.ErrorCode;
 import com.dasom.MemoReal.global.ipfs.dto.IpfsUploadResult;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.core.io.FileSystemResource;
+import org.springframework.core.io.ByteArrayResource;
 import org.springframework.http.*;
 import org.springframework.stereotype.Component;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.HttpServerErrorException;
 import org.springframework.web.client.RestTemplate;
-
-import java.io.File;
 
 @Component
 public class IpfsClient {
@@ -19,119 +22,91 @@ public class IpfsClient {
     @Value("${ipfs.api-base-url}")
     private String ipfsApiBaseUrl;
 
-    private final String MFS_BASE_PATH = "/test"; // MFS 폴더 경로
-
-    // RestTemplate 재사용용 필드
     private final RestTemplate restTemplate = new RestTemplate();
 
-    /**
-     * MFS의 /test 폴더 아래에 파일 업로드
-     */
-    public IpfsUploadResult uploadToMfs(File file) {
-        String mfsPath = MFS_BASE_PATH + "/" + file.getName();
-        String url = ipfsApiBaseUrl + "/files/write?arg=" + mfsPath + "&create=true&truncate=true";
+    public IpfsUploadResult upload(byte[] content, String filename) {
+        try {
+            String url = ipfsApiBaseUrl + "/add?pin=false"; // 테스트 단계에서는 비활성화(추후 운용단계 에서는 핀설정하게 변경)
 
-        // multipart/form-data 구성
-        MultiValueMap<String, Object> body = new LinkedMultiValueMap<>();
-        // Resource로 감싸서 전송
-        body.add("file", new FileSystemResource(file));
+            HttpHeaders headers = new HttpHeaders();
+            headers.setContentType(MediaType.MULTIPART_FORM_DATA);
 
-        HttpHeaders headers = new HttpHeaders();
-        headers.setContentType(MediaType.MULTIPART_FORM_DATA);
+            ByteArrayResource fileAsResource = new ByteArrayResource(content) {
+                @Override
+                public String getFilename() {
+                    return filename;
+                }
+            };
 
-        HttpEntity<MultiValueMap<String, Object>> requestEntity = new HttpEntity<>(body, headers);
+            MultiValueMap<String, Object> body = new LinkedMultiValueMap<>();
+            body.add("file", fileAsResource);
 
-        ResponseEntity<String> writeResponse = restTemplate.postForEntity(url, requestEntity, String.class);
+            HttpEntity<MultiValueMap<String, Object>> requestEntity = new HttpEntity<>(body, headers);
 
-        if (!writeResponse.getStatusCode().is2xxSuccessful()) {
-            throw new CustomException(ErrorCode.UPLOAD_FAILED, "MFS 파일 쓰기 실패: " + writeResponse.getStatusCode());
+            ResponseEntity<String> response = restTemplate.exchange(url, HttpMethod.POST, requestEntity, String.class);
+
+            if (response.getStatusCode() == HttpStatus.OK && response.getBody() != null) {
+                String responseBody = response.getBody();
+                String hash = extractHashFromResponse(responseBody);
+                return new IpfsUploadResult(hash, filename, content.length);
+            } else {
+                throw new CustomException(ErrorCode.UPLOAD_FAILED, "IPFS 업로드 실패: " + response.getStatusCode());
+            }
+
+        } catch (Exception e) {
+            throw new CustomException(ErrorCode.UPLOAD_FAILED, "IPFS 업로드 중 예외 발생: " + e.getMessage());
         }
-
-        // 파일 상태 조회는 기존 코드 유지
-        String statUrl = ipfsApiBaseUrl + "/files/stat?arg=" + mfsPath;
-        ResponseEntity<String> statResponse = restTemplate.postForEntity(statUrl, null, String.class);
-        if (!statResponse.getStatusCode().is2xxSuccessful()) {
-            throw new CustomException(ErrorCode.UPLOAD_FAILED, "MFS 파일 상태 조회 실패: " + statResponse.getStatusCode());
-        }
-
-        String bodyStr = statResponse.getBody();
-        if (bodyStr == null) {
-            throw new CustomException(ErrorCode.UPLOAD_FAILED, "MFS 파일 상태 응답 없음");
-        }
-
-        String hash = extractHashFromJson(bodyStr);
-
-        return new IpfsUploadResult(hash, file.getName(), file.length());
-
     }
 
-    /**
-     * MFS 내 /test 폴더에 저장된 파일 다운로드
-     */
-    public byte[] downloadFromMfs(String filename) {
+    private String extractHashFromResponse(String response) {
         try {
-            if (filename == null || filename.trim().isEmpty() || filename.endsWith("/")) {
-                throw new CustomException(ErrorCode.FILE_NOT_FOUND, "유효하지 않은 파일명입니다: " + filename);
+            ObjectMapper mapper = new ObjectMapper();
+            JsonNode root = mapper.readTree(response);
+            if (root.has("Hash")) {
+                return root.get("Hash").asText();
             }
+        } catch (JsonProcessingException e) {
+            throw new CustomException(ErrorCode.UPLOAD_FAILED, "응답 JSON 파싱 실패: " + e.getMessage());
+        }
+        throw new CustomException(ErrorCode.UPLOAD_FAILED, "응답에서 해시를 추출할 수 없습니다.");
+    }
 
-            if (!filename.startsWith("/")) {
-                filename = "/" + filename;
-            }
-
-            String targetPath = MFS_BASE_PATH + filename; // "/test/filename"
-
-            String url = ipfsApiBaseUrl + "/files/read?arg=" + targetPath;
+    public byte[] downloadByHash(String hash) {
+        try {
+            String url = ipfsApiBaseUrl + "/cat?arg=" + hash;
 
             HttpHeaders headers = new HttpHeaders();
             headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
 
-            HttpEntity<String> entity = new HttpEntity<>("", headers);
+            HttpEntity<Void> request = new HttpEntity<>(headers);
 
-            ResponseEntity<byte[]> response = restTemplate.exchange(
-                    url,
-                    HttpMethod.POST,  // GET이 아닌 POST로 변경해야 함
-                    entity,
-                    byte[].class
-            );
+            ResponseEntity<byte[]> response = restTemplate.exchange(url, HttpMethod.POST, request, byte[].class);
 
-            if (response.getStatusCode() == HttpStatus.OK) {
+            if (response.getStatusCode() == HttpStatus.OK && response.getBody() != null) {
                 return response.getBody();
             } else {
-                throw new CustomException(ErrorCode.FILE_NOT_FOUND, "MFS 파일 다운로드 실패: " + response.getStatusCode());
+                throw new CustomException(ErrorCode.CONTENT_DOWNLOAD_FAILED, "IPFS 다운로드 실패: " + response.getStatusCode());
             }
         } catch (Exception e) {
-            throw new CustomException(ErrorCode.FILE_NOT_FOUND, "MFS 요청 실패: " + e.getMessage());
+            throw new CustomException(ErrorCode.CONTENT_DOWNLOAD_FAILED, "IPFS 해시 다운로드 예외: " + e.getMessage());
         }
     }
 
-
-
-    /**
-     * MFS 내 /test 폴더에 저장된 파일 삭제
-     */
-    public void deleteFromMfs(String filename) {
+    public void deleteByHash(String hash) {
         try {
-            String targetPath = MFS_BASE_PATH + "/" + filename;
-            String url = ipfsApiBaseUrl + "/files/rm?arg=" + targetPath;
+            String url = ipfsApiBaseUrl + "/pin/rm?arg=" + hash;
 
-            ResponseEntity<String> response = restTemplate.postForEntity(url, null, String.class);
+            restTemplate.postForEntity(url, null, String.class);
 
-            if (!response.getStatusCode().is2xxSuccessful()) {
-                throw new CustomException(ErrorCode.CONTENT_DELETE_FAILED, "MFS 파일 삭제 실패: " + response.getStatusCode());
+        } catch (HttpClientErrorException | HttpServerErrorException e) {
+            String responseBody = e.getResponseBodyAsString();
+            if (responseBody.contains("not pinned")) {
+                // 이미 핀되어 있지 않으면 무시
+                return;
             }
+            throw new CustomException(ErrorCode.CONTENT_DELETE_FAILED, "IPFS 해시 삭제 예외: " + e.getMessage());
         } catch (Exception e) {
-            throw new CustomException(ErrorCode.CONTENT_DELETE_FAILED, "MFS 삭제 실패: " + e.getMessage());
+            throw new CustomException(ErrorCode.CONTENT_DELETE_FAILED, "IPFS 해시 삭제 예외: " + e.getMessage());
         }
-    }
-
-    /**
-     * 간단한 JSON 문자열에서 "Hash" 키의 값을 추출하는 메서드
-     */
-    private String extractHashFromJson(String json) {
-        // "Hash":"Qm..." 형태에서 값만 추출
-        int start = json.indexOf("\"Hash\":\"") + 7; // "Hash":" 길이 = 7
-        int end = json.indexOf("\"", start);
-        if (start < 7 || end < 0) return "";
-        return json.substring(start, end);
     }
 }

--- a/src/main/java/com/dasom/MemoReal/global/ipfs/IpfsUploader.java
+++ b/src/main/java/com/dasom/MemoReal/global/ipfs/IpfsUploader.java
@@ -1,0 +1,56 @@
+package com.dasom.MemoReal.global.ipfs;
+
+import com.dasom.MemoReal.global.exception.CustomException;
+import com.dasom.MemoReal.global.exception.ErrorCode;
+import com.dasom.MemoReal.global.ipfs.dto.IpfsUploadResult;
+import org.springframework.core.io.FileSystemResource;
+import org.springframework.http.*;
+import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+
+import java.io.File;
+
+@Component
+public class IpfsUploader {
+
+    public IpfsUploadResult upload(File file) {
+        try {
+            RestTemplate restTemplate = new RestTemplate();
+
+            MultiValueMap<String, Object> body = new LinkedMultiValueMap<>();
+            body.add("file", new FileSystemResource(file));
+
+            HttpHeaders headers = new HttpHeaders();
+            headers.setContentType(MediaType.MULTIPART_FORM_DATA);
+
+            HttpEntity<MultiValueMap<String, Object>> requestEntity = new HttpEntity<>(body, headers);
+
+            ResponseEntity<String> response = restTemplate.postForEntity(
+                    "http://localhost:5001/api/v0/add",
+                    requestEntity,
+                    String.class
+            );
+
+            if (response.getStatusCode().is2xxSuccessful()) {
+                String bodyStr = response.getBody();
+                if (bodyStr != null && bodyStr.contains("Hash")) {
+                    String hash = extractValue(bodyStr, "Hash");
+                    String name = extractValue(bodyStr, "Name");
+                    String size = extractValue(bodyStr, "Size");
+                    return new IpfsUploadResult(hash, name, Long.parseLong(size));
+                }
+            }
+            throw new CustomException(ErrorCode.UPLOAD_FAILED, "IPFS 응답 실패: " + response.getStatusCode());
+        } catch (Exception e) {
+            throw new CustomException(ErrorCode.UPLOAD_FAILED, "IPFS 요청 실패: " + e.getMessage());
+        }
+    }
+
+    private String extractValue(String json, String key) {
+        int start = json.indexOf("\"" + key + "\":\"") + key.length() + 4;
+        int end = json.indexOf("\"", start);
+        return json.substring(start, end);
+    }
+}

--- a/src/main/java/com/dasom/MemoReal/global/ipfs/dto/IpfsUploadResult.java
+++ b/src/main/java/com/dasom/MemoReal/global/ipfs/dto/IpfsUploadResult.java
@@ -1,0 +1,12 @@
+package com.dasom.MemoReal.global.ipfs.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class IpfsUploadResult {
+    private final String hash;
+    private final String fileName;
+    private final long fileSize;
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -19,3 +19,6 @@ spring:
     properties:
       hibernate:
         dialect: org.hibernate.dialect.MySQL8Dialect
+
+ipfs:
+  api-base-url: ${IPFS_API_BASE_URL}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -21,4 +21,5 @@ spring:
         dialect: org.hibernate.dialect.MySQL8Dialect
 
 ipfs:
-  api-base-url: ${IPFS_API_BASE_URL}
+  api-base-url: http://127.0.0.1:5001/api/v0
+  # ${IPFS_API_BASE_URL}

--- a/src/test/java/com/dasom/MemoReal/ContentFullIntegrationTest.java
+++ b/src/test/java/com/dasom/MemoReal/ContentFullIntegrationTest.java
@@ -1,0 +1,147 @@
+package com.dasom.MemoReal;
+
+import com.dasom.MemoReal.domain.Capsule.dto.ContentUploadRequest;
+import com.dasom.MemoReal.domain.Capsule.dto.MetadataDto;
+import com.dasom.MemoReal.domain.Capsule.service.ContentService;
+import com.dasom.MemoReal.domain.user.entity.User;
+import com.dasom.MemoReal.domain.user.repository.UserRepository;
+import com.dasom.MemoReal.global.exception.CustomException;
+import org.junit.jupiter.api.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@Transactional
+public class ContentFullIntegrationTest {
+
+    private static final Logger logger = LoggerFactory.getLogger(ContentFullIntegrationTest.class);
+
+    @Autowired
+    private ContentService contentService;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    private Long testUserId;
+    private MockMultipartFile testFile;
+
+    @BeforeEach
+    void setUp() {
+        User testUser = User.builder()
+                .username("testuser")
+                .password("encodedpassword")
+                .email("testuser@example.com")
+                .roles(new ArrayList<>() {{
+                    add("USER");
+                }})
+                .build();
+        userRepository.save(testUser);
+        testUserId = testUser.getId();
+
+        testFile = new MockMultipartFile(
+                "file",
+                "testfile.txt",
+                "text/plain",
+                "This is a test file content.".getBytes()
+        );
+        logger.info("\n"); // 한 줄 띄우기 (테스트 시작 전)
+    }
+
+    private MetadataDto uploadTestFile() {
+        ContentUploadRequest request = ContentUploadRequest.builder()
+                .title("Title")
+                .description("Desc")
+                .category("Category")
+                .tags("tag1,tag2")
+                .accessCondition(LocalDate.now().toString())
+                .build();
+        return contentService.upload(testFile, request, testUserId);
+    }
+
+    @Test
+    void testUpload() {
+        logger.info("========== testUpload 시작 ==========");
+        MetadataDto metadata = uploadTestFile();
+
+        assertNotNull(metadata);
+        assertEquals("Title", metadata.getTitle());
+        logger.info("testUpload 성공 - 제목: {}", metadata.getTitle());
+        logger.info("========== testUpload 종료 ==========\n");
+    }
+
+    @Test
+    void testRetrieveMetadata() {
+        logger.info("========== testRetrieveMetadata 시작 ==========");
+        MetadataDto uploaded = uploadTestFile();
+
+        MetadataDto retrieved = contentService.retrieveMetadata(uploaded.getId());
+        assertEquals(uploaded.getTitle(), retrieved.getTitle());
+        logger.info("testRetrieveMetadata 성공 - 제목: {}", retrieved.getTitle());
+        logger.info("========== testRetrieveMetadata 종료 ==========\n");
+    }
+
+    @Test
+    void testFindAllByUserId() {
+        logger.info("========== testFindAllByUserId 시작 ==========");
+        uploadTestFile();
+
+        List<MetadataDto> list = contentService.findAllByUserId(testUserId);
+        assertFalse(list.isEmpty());
+        logger.info("testFindAllByUserId 성공 - 메타데이터 수: {}", list.size());
+        logger.info("========== testFindAllByUserId 종료 ==========\n");
+    }
+
+    @Test
+    void testDownloadFile() {
+        logger.info("========== testDownloadFile 시작 ==========");
+        MetadataDto uploaded = uploadTestFile();
+
+        byte[] fileData = contentService.downloadFile(uploaded.getId(), testUserId);
+        assertNotNull(fileData);
+        assertTrue(fileData.length > 0);
+        logger.info("testDownloadFile 성공 - 파일 크기: {} bytes", fileData.length);
+
+        // 파일 본문 출력 (텍스트 파일일 경우)
+        String content = new String(fileData);
+        logger.info("다운로드된 파일 내용: {}", content);
+
+        logger.info("========== testDownloadFile 종료 ==========\n");
+    }
+
+    @Test
+    void testUpdateMetadataFields() {
+        logger.info("========== testUpdateMetadataFields 시작 ==========");
+        MetadataDto uploaded = uploadTestFile();
+
+        Map<String, Object> updates = Map.of("title", "Updated Title");
+        contentService.updateMetadataFields(uploaded.getId(), updates, testUserId);
+
+        MetadataDto updated = contentService.retrieveMetadata(uploaded.getId());
+        assertEquals("Updated Title", updated.getTitle());
+        logger.info("testUpdateMetadataFields 성공 - 수정된 제목: {}", updated.getTitle());
+        logger.info("========== testUpdateMetadataFields 종료 ==========\n");
+    }
+
+    @Test
+    void testDeleteMetadataAndContent() {
+        logger.info("========== testDeleteMetadataAndContent 시작 ==========");
+        MetadataDto uploaded = uploadTestFile();
+        Long id = uploaded.getId();
+
+        contentService.deleteMetadataAndContent(id, testUserId);
+        logger.info("testDeleteMetadataAndContent - 메타데이터 및 컨텐츠 삭제 요청 완료");
+
+        assertThrows(CustomException.class, () -> contentService.retrieveMetadata(id));
+        logger.info("testDeleteMetadataAndContent 성공 - 삭제 후 메타데이터 조회 시 예외 발생 확인");
+        logger.info("========== testDeleteMetadataAndContent 종료 ==========\n");
+    }
+}

--- a/src/test/java/com/dasom/MemoReal/ContentFullIntegrationTest.java
+++ b/src/test/java/com/dasom/MemoReal/ContentFullIntegrationTest.java
@@ -3,15 +3,20 @@ package com.dasom.MemoReal;
 import com.dasom.MemoReal.domain.Capsule.dto.ContentUploadRequest;
 import com.dasom.MemoReal.domain.Capsule.dto.MetadataDto;
 import com.dasom.MemoReal.domain.Capsule.service.ContentService;
-import com.dasom.MemoReal.domain.user.entity.User;
-import com.dasom.MemoReal.domain.user.repository.UserRepository;
+import com.dasom.MemoReal.domain.user.dto.JoinDTO;
+import com.dasom.MemoReal.domain.user.service.UserService;
 import com.dasom.MemoReal.global.exception.CustomException;
+import com.dasom.MemoReal.global.jwt.dto.JwtTokenDTO;
+import com.dasom.MemoReal.global.jwt.provider.JwtTokenProvider;
+import com.dasom.MemoReal.global.security.util.SecurityUtil;
 import org.junit.jupiter.api.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
@@ -29,33 +34,50 @@ public class ContentFullIntegrationTest {
     private ContentService contentService;
 
     @Autowired
-    private UserRepository userRepository;
+    private UserService  userService;
+
+    @Autowired
+    private JwtTokenProvider jwtTokenProvider;
 
     private Long testUserId;
     private MockMultipartFile testFile;
 
     @BeforeEach
     void setUp() {
-        User testUser = User.builder()
+        // 1. 회원가입
+        JoinDTO joinDTO = JoinDTO.builder()
                 .username("testuser")
-                .password("encodedpassword")
+                .password("1234")
                 .email("testuser@example.com")
                 .roles(new ArrayList<>() {{
                     add("USER");
                 }})
                 .build();
-        userRepository.save(testUser);
-        testUserId = testUser.getId();
+        userService.join(joinDTO);
 
+        // 2. 로그인하여 JWT 토큰 생성
+        JwtTokenDTO tokenDTO = userService.login("testuser@example.com", "1234");
+
+        // 3. JWT 토큰에서 사용자 인증 설정
+        Authentication authentication = jwtTokenProvider.getAuthentication(tokenDTO.getAccessToken());
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+
+        // 4. SecurityContextHolder에서 유저 이름 추출
+        String username = SecurityUtil.getCurrentUsername();
+
+        // 5. 유저 이름으로부터 ID 조회
+        testUserId = userService.getUserIdByUsername(username);
+
+        // 6. 테스트용 파일 생성
         testFile = new MockMultipartFile(
                 "file",
                 "testfile.txt",
                 "text/plain",
                 "This is a test file content.".getBytes()
         );
+
         logger.info("\n"); // 한 줄 띄우기 (테스트 시작 전)
     }
-
     private MetadataDto uploadTestFile() {
         ContentUploadRequest request = ContentUploadRequest.builder()
                 .title("Title")

--- a/src/test/java/com/dasom/MemoReal/ContentFullIntegrationTest.java
+++ b/src/test/java/com/dasom/MemoReal/ContentFullIntegrationTest.java
@@ -166,4 +166,49 @@ public class ContentFullIntegrationTest {
         assertThrows(CustomException.class, () -> contentService.retrieveMetadata(id));
         logger.info("testDeleteMetadataAndContent 성공 - 삭제 후 메타데이터 조회 시 예외 발생 확인");
     }
+    @Test
+    void testUploadImageFile() {
+        logger.info("========== testUploadImageFile 시작 ==========");
+
+        // 샘플 이미지 바이너리 (간단한 1픽셀 PNG 이미지)
+        byte[] imageBytes = new byte[]{
+                (byte) 0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A,
+                0x00, 0x00, 0x00, 0x0D, 0x49, 0x48, 0x44, 0x52,
+                0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01,
+                0x08, 0x06, 0x00, 0x00, 0x00, 0x1F, 0x15, (byte) 0xC4, (byte) 0x89,
+                0x00, 0x00, 0x00, 0x0A, 0x49, 0x44, 0x41, 0x54,
+                0x78, (byte) 0x9C, 0x63, 0x60, 0x00, 0x00, 0x00, 0x02,
+                0x00, 0x01, (byte) 0xE2, 0x21, (byte) 0xBC, 0x33,
+                0x00, 0x00, 0x00, 0x00, 0x49, 0x45, 0x4E, 0x44,
+                (byte) 0xAE, 0x42, 0x60, (byte) 0x82
+        };
+
+        // 이미지 파일 생성
+        MockMultipartFile imageFile = new MockMultipartFile(
+                "file",
+                "test-image.png",
+                "image/png",
+                imageBytes
+        );
+
+        // 요청 정보 생성
+        ContentUploadRequest request = ContentUploadRequest.builder()
+                .title("Test Image")
+                .description("Image description")
+                .category("Image")
+                .tags("image,test")
+                .accessCondition(LocalDate.now().toString())
+                .build();
+
+        // 업로드
+        MetadataDto metadata = contentService.upload(imageFile, request, testUserId);
+        assertNotNull(metadata);
+        logger.info("testUploadImageFile 업로드 성공 - IPFS 해시: {}", metadata.getFileHash());
+
+        // 다운로드
+        byte[] downloaded = contentService.downloadFile(metadata.getId(), testUserId);
+        assertNotNull(downloaded);
+        assertEquals(imageBytes.length, downloaded.length, "업로드한 이미지와 다운로드한 이미지 크기가 달라야 하지 않습니다.");
+        logger.info("testUploadImageFile 다운로드 성공 - 바이트 수: {}", downloaded.length);
+    }
 }

--- a/src/test/java/com/dasom/MemoReal/ContentFullIntegrationTest.java
+++ b/src/test/java/com/dasom/MemoReal/ContentFullIntegrationTest.java
@@ -73,9 +73,11 @@ public class ContentFullIntegrationTest {
         MetadataDto metadata = uploadTestFile();
 
         assertNotNull(metadata);
-        assertEquals("Title", metadata.getTitle());
-        logger.info("testUpload 성공 - 제목: {}", metadata.getTitle());
-        logger.info("========== testUpload 종료 ==========\n");
+
+        // title 대신 IPFS 해시값을 출력 및 비교
+        String expectedHash = metadata.getFileHash();
+        assertNotNull(expectedHash, "해시 값이 null이면 안됩니다.");
+        logger.info("testUpload 성공 - IPFS 해시: {}", expectedHash);
     }
 
     @Test
@@ -86,18 +88,19 @@ public class ContentFullIntegrationTest {
         MetadataDto retrieved = contentService.retrieveMetadata(uploaded.getId());
         assertEquals(uploaded.getTitle(), retrieved.getTitle());
         logger.info("testRetrieveMetadata 성공 - 제목: {}", retrieved.getTitle());
-        logger.info("========== testRetrieveMetadata 종료 ==========\n");
     }
 
     @Test
     void testFindAllByUserId() {
         logger.info("========== testFindAllByUserId 시작 ==========");
+        // 2개 이상의 콘텐츠 업로드
+        uploadTestFile();
         uploadTestFile();
 
         List<MetadataDto> list = contentService.findAllByUserId(testUserId);
         assertFalse(list.isEmpty());
+        assertTrue(list.size() >= 2, "2개 이상의 메타데이터가 조회되어야 합니다.");
         logger.info("testFindAllByUserId 성공 - 메타데이터 수: {}", list.size());
-        logger.info("========== testFindAllByUserId 종료 ==========\n");
     }
 
     @Test
@@ -114,7 +117,6 @@ public class ContentFullIntegrationTest {
         String content = new String(fileData);
         logger.info("다운로드된 파일 내용: {}", content);
 
-        logger.info("========== testDownloadFile 종료 ==========\n");
     }
 
     @Test
@@ -128,7 +130,6 @@ public class ContentFullIntegrationTest {
         MetadataDto updated = contentService.retrieveMetadata(uploaded.getId());
         assertEquals("Updated Title", updated.getTitle());
         logger.info("testUpdateMetadataFields 성공 - 수정된 제목: {}", updated.getTitle());
-        logger.info("========== testUpdateMetadataFields 종료 ==========\n");
     }
 
     @Test
@@ -142,6 +143,5 @@ public class ContentFullIntegrationTest {
 
         assertThrows(CustomException.class, () -> contentService.retrieveMetadata(id));
         logger.info("testDeleteMetadataAndContent 성공 - 삭제 후 메타데이터 조회 시 예외 발생 확인");
-        logger.info("========== testDeleteMetadataAndContent 종료 ==========\n");
     }
 }


### PR DESCRIPTION
# [feat] IPFS 연동을 통한 캡슐 컨텐츠 업로드 및 메타데이터 저장

## 😺 Issue
- #19

## ✅ 작업 리스트
- content 관련 service, entity, repository, dto, controller 생성
- ErrorCode 에 대응하는 커스텀 에러 추가
- SecurityUtil 이용하여 UserService 에 userid 추출하는 기능 추가
- IPFS 담당 클래스 global 에 생성 및 연동하여, 콘텐츠 업로드, 핀해제 및 gc 요청, 다운로드 하는 기능 추가
- application.yml 에 ipfs url 추가
- 테스트 코드 작성하여 각 기능 빠르게 테스트 하게 구현

## ⚙️ 작업 내용
- service에서 메타데이터는 직접 처리하고, 컨텐츠 상호작용은 IpfsClient에 필요한 정보(ex: 해시,파일 등)를 넘겨줘서 처리하며 기능으로
1. 캡슐(콘텐츠, 메타데이터) 업로드
2. 메타데이터의 id 기반 메타데이터 조회
3. 유저id 로 유저의 모든 메타데이터 조회
4. 특정 메타데이터의 일부 정보(title,description) 수정
5. 캡슐 삭제
6. 캡슐 조회 의 기능을 가짐

- 메타데이터는 클라이언트에서 title, description, category 와 같은 요소를 넘겨 받고 컨텐츠를 IPFS에 업로드 후 hash, fileName, fileSize 를 받아 둘을 결합하여 DB에 저장하며, userid를 입력해 소유자가 누구인지 식별

- METADATA_NOT_FOUND, FILE_NOT_FOUND, ACCESS_DENIED 등의 커스텀 에러를 추가

- IpfsClient에서는 RestTemplate의 post를 사용해서 업로드, 다운로드, 핀해제 등의 요소를 처리

- application.yml 에 ipfs url 속성을 추가해 env 파일의 값만 바꾸면 전체에 반영됨

- SecurityUtil 의 getCurrentUsername 과 UserService 에 추가된 getUserIdByUsername 을 통해 ContentController에서 userid를 jwt를 통해서 추출하여 사용

## 📷 테스트 / 구현 내용
<img width="876" height="537" alt="image" src="https://github.com/user-attachments/assets/43ef8868-dbed-4665-b1fb-34b503a874d0" />
<img width="980" height="74" alt="image" src="https://github.com/user-attachments/assets/3ab1cddc-d800-4fb8-b7a0-5bef89191fcf" />
